### PR TITLE
Major performance improvements to I/O and vertex solver

### DIFF
--- a/docs/main/source/models/vertex/solver/solver.rst
+++ b/docs/main/source/models/vertex/solver/solver.rst
@@ -357,17 +357,27 @@ to roll the sheet into a cylinder, ::
 The vertex model solver also supports constructing mesh objects using data in
 :ref:`3D model formats <file_io>`.
 A body can be constructed from a :py:class:`Mesh3DF <tissue_forge.io.Mesh3DF>` instance, and
-a surface can be constructed from a :py:class:`Face3DF <tissue_forge.io.Face3DF>` instance, ::
+a surface can be constructed from a :py:class:`Face3DF <tissue_forge.io.Face3DF>` instance
+or list of them, ::
 
     # Import a two-dimensional mesh from a 3DF
     obj_struct: tf.io.ThreeDFStructure = tf.io.fromFile3DF('my_blender_mesh2d.obj')
     # Build a two-dimensional cell for each imported face
-    for f in obj_struct.faces:
-        cell_type(f)
+    cell_type(face_data=obj_struct.faces)
     # Verify each newly created vertex position
     for s in cell_type:
         for v in s.vertices:
             print(f'Vertex {v.id}: {v.position}')
+
+.. note::
+
+    Constructing surfaces from a list of imported faces can be performed by either purging (default)
+    or keeping the topology of the imported faces. When purging the imported topology, new vertices are
+    created for each imported face, and the topology can be reconstructed with :meth:`Surface.sew`.
+    Reconstructing the topology can be slow depending on the details of the imported mesh but can act
+    as a safeguard against errors in mesh topology that are hard to detect.
+    Constructing surfaces while keeping the topology of imported faces can be enabled by setting the
+    keyword argument ``safe_face_data`` to ``False``.
 
 Mesh objects provide methods for conveniently finding other objects according to their neighborhood
 and topology. For example, a vertex that defines a surface can be retrieved from the surface

--- a/source/io/tfThreeDFStructure.cpp
+++ b/source/io/tfThreeDFStructure.cpp
@@ -31,9 +31,11 @@
 
 #include <algorithm>
 #include <limits>
+#include <numeric>
 #include <random>
 
 #include "tfThreeDFStructure.h"
+#include "tfTaskScheduler.h"
 
 
 namespace TissueForge {
@@ -113,26 +115,28 @@ namespace TissueForge::io {
         return S_OK;
     }
 
-    std::vector<unsigned int> buildVertexConsolidation(std::vector<FVector3> vPos, const FloatP_t &tol=1E-6) {
+    std::vector<unsigned int> buildVertexConsolidation(const std::vector<FVector3>& vPos, const FloatP_t &tol=1E-6) {
+
         unsigned int numV = vPos.size();
-        std::vector<unsigned int> result;
-        result.reserve(numV);
-        unsigned int consolidated = 0;
+        std::vector<unsigned int> result(numV);
+        std::iota(result.begin(), result.end(), 0);
 
-        for(unsigned int vIdx = 0; vIdx < numV; vIdx++) {
-            result.push_back(vIdx);
-            auto vp = vPos[vIdx];
+        auto func = [&vPos, &result, &tol, &numV](int tid) -> void {
+            const FloatP_t& tol2 = tol * tol;
+            for(unsigned int vIdx = tid; vIdx < numV; vIdx += ThreadPool::size()) {
+                auto vp = vPos[vIdx];
 
-            for(unsigned int vvIdx = 0; vvIdx < vIdx; vvIdx++) {
-                if((vp - vPos[vvIdx]).length() < tol) {
-                    result[vIdx] = vvIdx;
-                    consolidated++;
-                    break;
+                for(unsigned int vvIdx = 0; vvIdx < vIdx; vvIdx++) {
+                    if((vp - vPos[vvIdx]).dot() < tol2) {
+                        result[vIdx] = vvIdx;
+                        break;
+                    }
                 }
             }
-        }
+        };
+        parallel_for(ThreadPool::size(), func);
 
-        TF_Log(LOG_TRACE) << "Consolidated vertices: " << consolidated;
+        TF_Log(LOG_TRACE) << "Consolidated vertices";
 
         return result;
     }
@@ -144,7 +148,7 @@ namespace TissueForge::io {
      * @param vPos 
      * @return std::vector<FVector3> 
      */
-    FVector3 faceNormal(std::vector<unsigned int> vIndices, std::vector<FVector3> vPos, std::vector<FVector3> vNorm) {
+    FVector3 faceNormal(const std::vector<unsigned int>& vIndices, const std::vector<FVector3>& vPos, const std::vector<FVector3>& vNorm) {
         FVector3 vap = vPos[vIndices[0]],  vbp = vPos[vIndices[1]],  vcp = vPos[vIndices[2]];
         FVector3 vbn = vNorm[vIndices[1]];
 
@@ -219,32 +223,27 @@ namespace TissueForge::io {
             TF_Log(LOG_TRACE) << "Mesh " << mIdx << ": " << aim->mNumVertices << " vertices, " << aim->mNumFaces << " faces";
 
             // Construct and add every vertex while keeping original ordering for future indexing
-            ThreeDFVertexData *vertex;
-            std::vector<ThreeDFVertexData*> vertices;
-            std::vector<FVector3> vPos, vNorm;
-            vertices.reserve(aim->mNumVertices);
-            vPos.reserve(aim->mNumVertices);
-            vNorm.reserve(aim->mNumVertices);
-            for(unsigned int vIdx = 0; vIdx < aim->mNumVertices; vIdx++) {
+            std::vector<ThreeDFVertexData*> vertices(aim->mNumVertices);
+            std::vector<FVector3> vPos(aim->mNumVertices), vNorm(aim->mNumVertices);
+            parallel_for(
+                aim->mNumVertices, 
+                [&aim, &meshTransform, &vertices, &vNorm, &vPos](int vIdx) -> void {
+                    auto aiv = aim->mVertices[vIdx];
+                    auto ain = aim->mNormals[vIdx];
+                    
+                    FVector4 ait = {(FloatP_t)aiv.x, (FloatP_t)aiv.y, (FloatP_t)aiv.z, 1.f};
+                    FVector3 position = (meshTransform * ait).xyz();
+                    ThreeDFVertexData* vertex = new ThreeDFVertexData(position);
 
-                auto aiv = aim->mVertices[vIdx];
-                auto ain = aim->mNormals[vIdx];
-                
-                FVector4 ait = {(FloatP_t)aiv.x, (FloatP_t)aiv.y, (FloatP_t)aiv.z, 1.f};
-                FVector3 position = (meshTransform * ait).xyz();
-                vertex = new ThreeDFVertexData(position);
+                    vPos[vIdx] = position;
 
-                vPos.push_back(position);
-
-                FVector3 aiu = {(FloatP_t)ain.x, (FloatP_t)ain.y, (FloatP_t)ain.z};
-                FVector3 normal = meshTransform.rotation() * aiu;
-                vNorm.push_back(normal);
-
-                TF_Log(LOG_TRACE) << "Vertex " << vIdx << ": " << position << ", " << normal;
-                
-                vertices.push_back(vertex);
-
-            }
+                    FVector3 aiu = {(FloatP_t)ain.x, (FloatP_t)ain.y, (FloatP_t)ain.z};
+                    FVector3 normal = meshTransform.rotation() * aiu;
+                    vNorm[vIdx] = normal;
+                    
+                    vertices[vIdx] = vertex;
+                }
+            );
 
             // Consolidate
 
@@ -252,6 +251,8 @@ namespace TissueForge::io {
             for(unsigned int vIdx = 0; vIdx < vPos.size(); vIdx++) 
                 if(vcIndices[vIdx] == vIdx) 
                     this->add(vertices[vIdx]);
+                else 
+                    delete vertices[vIdx];
 
             // If there are faces, construct them and their edges and add them
             if(aim->HasFaces()) {
@@ -261,49 +262,92 @@ namespace TissueForge::io {
                 mesh->name = std::string(aim->mName.C_Str());
 
                 // Build and add faces and edges
-                
-                for(unsigned int fIdx = 0; fIdx < aim->mNumFaces; fIdx++) {
-                    auto aif = aim->mFaces[fIdx];
 
-                    std::vector<ThreeDFVertexData*> vertices_f;
-                    std::vector<unsigned int> fvIndices;
-                    vertices_f.reserve(aif.mNumIndices + 1);
-                    fvIndices.reserve(aif.mNumIndices);
-                    for(unsigned int fvIdx = 0; fvIdx < aif.mNumIndices; fvIdx++) { 
-                        unsigned int vIdx = aif.mIndices[fvIdx];
-                        vertices_f.push_back(vertices[vcIndices[vIdx]]);
-                        fvIndices.push_back(vIdx);
+                std::vector<ThreeDFFaceData*> newFaces(aim->mNumFaces, 0);
+                std::vector<std::vector<ThreeDFVertexData*> > newFacesVertexData(aim->mNumFaces);
+                std::vector<std::vector<unsigned int> > newFacesVertexIndexData(aim->mNumFaces);
+                std::vector<std::vector<ThreeDFEdgeData*> > newFacesEdgeData(aim->mNumFaces);
+
+                parallel_for(
+                    aim->mNumFaces, 
+                    [&newFacesVertexData, &newFacesVertexIndexData, &newFaces, &aim, &vertices, &vcIndices](int fIdx) -> void {
+                        auto aif = aim->mFaces[fIdx];
+
+                        std::vector<ThreeDFVertexData*>& vertices_f = newFacesVertexData[fIdx];
+                        std::vector<unsigned int>& fvIndices = newFacesVertexIndexData[fIdx];
+                        vertices_f.reserve(aif.mNumIndices + 1);
+                        fvIndices.reserve(aif.mNumIndices);
+                        for(unsigned int fvIdx = 0; fvIdx < aif.mNumIndices; fvIdx++) { 
+                            unsigned int vIdx = aif.mIndices[fvIdx];
+                            vertices_f.push_back(vertices[vcIndices[vIdx]]);
+                            fvIndices.push_back(vcIndices[vIdx]);
+                        }
+
+                        vertices_f.push_back(vertices_f[0]);
+                        newFaces[fIdx] = new ThreeDFFaceData();
+                    }
+                );
+
+                std::vector<std::tuple<ThreeDFVertexData*, ThreeDFVertexData*, unsigned int> > _newFacesNewEdgeData;
+                std::vector<std::vector<std::tuple<ThreeDFVertexData*, ThreeDFVertexData*, unsigned int> > > newFacesNewEdgeData(ThreadPool::size());
+                parallel_for(
+                    ThreadPool::size(), 
+                    [&newFacesEdgeData, &newFacesNewEdgeData, &newFacesVertexData, &newFaces, &aim](int tid) -> void {
+                        std::vector<std::tuple<ThreeDFVertexData*, ThreeDFVertexData*, unsigned int> >& newFacesNewEdgeDataThread = newFacesNewEdgeData[tid];
+
+                        for(unsigned int fIdx = tid; fIdx < aim->mNumFaces; fIdx += ThreadPool::size()) {
+                            auto aif = aim->mFaces[fIdx];
+
+                            std::vector<ThreeDFVertexData*> vertices_f = newFacesVertexData[fIdx];
+
+                            ThreeDFVertexData *va, *vb;
+                            ThreeDFEdgeData *edge;
+                            ThreeDFFaceData *face = newFaces[fIdx];
+                            for(unsigned int fvIdx = 0; fvIdx < aif.mNumIndices; fvIdx++) {
+                                va = vertices_f[fvIdx];
+                                vb = vertices_f[fvIdx + 1];
+                                edge = NULL;
+                                for(auto e : va->edges) 
+                                    if(e->has(vb)) {
+                                        edge = e;
+                                        newFacesEdgeData[fIdx].push_back(e);
+                                        break;
+                                    }
+                                if(edge == NULL) {
+                                    newFacesNewEdgeDataThread.push_back({va, vb, fIdx});
+                                }
+                            }
+                        }
+                    }
+                );
+
+                for(auto& newFacesNewEdgeDataThread : newFacesNewEdgeData) 
+                    for(auto& newEdgeData : newFacesNewEdgeDataThread) {
+                        ThreeDFVertexData* va, *vb;
+                        unsigned int fIdx;
+                        std::tie(va, vb, fIdx) = newEdgeData;
+                        ThreeDFEdgeData* edge = new ThreeDFEdgeData(va, vb);
+                        this->add(edge);
+                        newFacesEdgeData[fIdx].push_back(edge);
                     }
 
-                    vertices_f.push_back(vertices_f[0]);
-
-                    ThreeDFVertexData *va, *vb;
-                    ThreeDFEdgeData *edge;
-                    ThreeDFFaceData *face = new ThreeDFFaceData();
-                    for(unsigned int fvIdx = 0; fvIdx < aif.mNumIndices; fvIdx++) {
-                        va = vertices_f[fvIdx];
-                        vb = vertices_f[fvIdx + 1];
-                        edge = NULL;
-                        for(auto e : va->edges) 
-                            if(e->has(vb)) {
-                                edge = e;
-                                break;
-                            }
-                        if(edge == NULL) {
-                            edge = new ThreeDFEdgeData(va, vb);
-                            this->add(edge);
-                        }
-                        
+                for(unsigned int fIdx = 0; fIdx < aim->mNumFaces; fIdx++) {
+                    ThreeDFFaceData *face = newFaces[fIdx];
+                    for(auto& edge : newFacesEdgeData[fIdx]) {
                         face->edges.push_back(edge);
                         edge->faces.push_back(face);
                     }
-                    face->normal = faceNormal(fvIndices, vPos, vNorm);
-
                     mesh->faces.push_back(face);
                     face->meshes.push_back(mesh);
                     this->add(face);
-
                 }
+
+                parallel_for(
+                    aim->mNumFaces, 
+                    [&newFaces, &vPos, &vNorm, &newFacesVertexIndexData](int fIdx) -> void {
+                        newFaces[fIdx]->normal = faceNormal(newFacesVertexIndexData[fIdx], vPos, vNorm);
+                    }
+                );
 
                 // Add final data for this mesh
 

--- a/source/models/vertex/solver/tfBody.h
+++ b/source/models/vertex/solver/tfBody.h
@@ -161,6 +161,16 @@ namespace TissueForge::models::vertex {
         static HRESULT destroy(BodyHandle &target);
 
         /**
+         * @brief Destroy bodies. 
+         * 
+         * Any resulting surfaces without a body are also destroyed. 
+         * 
+         * @param target handles to a body
+         * @return HRESULT 
+         */
+        static HRESULT destroy(const std::vector<Body*>& toRemove);
+
+        /**
          * @brief Get the body type
          */
         BodyType *type() const;
@@ -175,7 +185,7 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the surfaces that define the body
          */
-        std::vector<Surface*> getSurfaces() const { return surfaces; }
+        const std::vector<Surface*>& getSurfaces() const { return surfaces; }
 
         /**
          * @brief Get the vertices that define the body
@@ -222,7 +232,7 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the mass density
          */
-        FloatP_t getDensity() const { return density; }
+        const FloatP_t& getDensity() const { return density; }
 
         /**
          * @brief Set the mass density
@@ -234,7 +244,7 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the centroid
          */
-        FVector3 getCentroid() const { return centroid; }
+        const FVector3& getCentroid() const { return centroid; }
 
         /**
          * @brief Get the velocity, calculated as the velocity of the centroid
@@ -244,12 +254,12 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the surface area
          */
-        FloatP_t getArea() const { return area; }
+        const FloatP_t& getArea() const { return area; }
 
         /**
          * @brief Get the volume
          */
-        FloatP_t getVolume() const { return volume; }
+        const FloatP_t& getVolume() const { return volume; }
 
         /**
          * @brief Get the mass
@@ -671,6 +681,13 @@ namespace TissueForge::models::vertex {
         HRESULT remove(const BodyHandle &i);
 
         /**
+         * @brief Remove instances
+         * 
+         * @param i instances to remove
+         */
+        HRESULT remove(const std::vector<BodyHandle>& i);
+
+        /**
          * @brief list of instances that belong to this type
          */
         std::vector<BodyHandle> getInstances();
@@ -753,6 +770,16 @@ inline std::ostream &operator<<(std::ostream& os, const TissueForge::models::ver
 {
     os << o.str().c_str();
     return os;
+}
+
+namespace std {
+
+    template <> 
+    struct hash<TissueForge::models::vertex::BodyHandle> {
+        size_t operator() (const TissueForge::models::vertex::BodyHandle& h) const {
+            return hash<int>()(h.id);
+        }
+    };
 }
 
 #endif // _MODELS_VERTEX_SOLVER_TFBODY_H_

--- a/source/models/vertex/solver/tfMesh.cpp
+++ b/source/models/vertex/solver/tfMesh.cpp
@@ -41,9 +41,14 @@ using namespace TissueForge;
 using namespace TissueForge::models::vertex;
 
 
+#define TF_INVALIDOBJRM_MSG "Invalid mesh object passed for remove."
+#define TF_MESH_OBJCHECK(obj) !(obj) || (obj)->objectId() < 0
+#define TF_MESH_OBJINVSIZECHECK(obj, sz) (obj)->_objId >= (sz)
+
+
 template <typename T> 
 HRESULT Mesh_checkStoredObj(T *obj) {
-    if(!obj || obj->objectId() < 0) {
+    if(TF_MESH_OBJCHECK(obj)) {
         TF_Log(LOG_ERROR);
         return E_FAIL;
     }
@@ -54,7 +59,7 @@ HRESULT Mesh_checkStoredObj(T *obj) {
 
 #define TF_MESH_OBJINVCHECK(obj, sz) \
     { \
-        if(obj->_objId >= sz) { \
+        if(TF_MESH_OBJINVSIZECHECK(obj, sz)) { \
             TF_Log(LOG_ERROR) << "Object with id " << obj->_objId << " exceeds inventory (" << sz << ")"; \
             return E_FAIL; \
         } \
@@ -297,6 +302,66 @@ HRESULT Mesh::allocateBody(Body **obj) {
     return S_OK;
 }
 
+HRESULT Mesh::allocateVertices(Vertex ***objs, const size_t& numObjs) {
+    // Check for available space; reallocate and reassign throughout if necessary
+    const int numNeeded = (int)numObjs - (int)vertexIdsAvail.size();
+    if(numNeeded > 0 && incrementVertices(numNeeded) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    for(unsigned int i = 0; i < numObjs; i++) {
+        std::set<unsigned int>::iterator itr = vertexIdsAvail.begin();
+        int objId = (int)*itr;
+        vertexIdsAvail.erase(itr);
+        auto obj = &(*objs)[i];
+        *obj = &(*vertices)[objId];
+        (*obj)->_objId = objId;
+    }
+    nr_vertices += numObjs;
+    return S_OK;
+}
+
+HRESULT Mesh::allocateSurfaces(Surface ***objs, const size_t& numObjs) {
+    // Check for available space; reallocate and reassign throughout if necessary
+    const int numNeeded = (int)numObjs - (int)surfaceIdsAvail.size();
+    if(numNeeded > 0 && incrementSurfaces(numNeeded) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    for(unsigned int i = 0; i < numObjs; i++) {
+        std::set<unsigned int>::iterator itr = surfaceIdsAvail.begin();
+        int objId = (int)*itr;
+        surfaceIdsAvail.erase(itr);
+        auto obj = &(*objs)[i];
+        *obj = &(*surfaces)[objId];
+        (*obj)->_objId = objId;
+    }
+    nr_surfaces += numObjs;
+    return S_OK;
+}
+
+HRESULT Mesh::allocateBodies(Body ***objs, const size_t& numObjs) {
+    // Check for available space; reallocate and reassign throughout if necessary
+    const int numNeeded = (int)numObjs - (int)bodyIdsAvail.size();
+    if(numNeeded > 0 && incrementBodies(numNeeded) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    for(unsigned int i = 0; i < numObjs; i++) {
+        std::set<unsigned int>::iterator itr = bodyIdsAvail.begin();
+        int objId = (int)*itr;
+        bodyIdsAvail.erase(itr);
+        auto obj = &(*objs)[i];
+        *obj = &(*bodies)[objId];
+        (*obj)->_objId = objId;
+    }
+    nr_bodies++;
+    return S_OK;
+}
+
 HRESULT Mesh::ensureAvailableVertices(const size_t &numAlloc) {
     int nr_diff = vertices->size() - nr_vertices - numAlloc;
     return nr_diff >= 0 ? S_OK : incrementVertices(-nr_diff);
@@ -327,6 +392,23 @@ HRESULT Mesh::create(Vertex **obj, const unsigned int &pid) {
     return S_OK;
 }
 
+HRESULT Mesh::create(Vertex*** objs, const std::vector<unsigned int>& pids) {
+    isDirty = true;
+    if(_solver) 
+        _solver->setDirty(true);
+
+    if(allocateVertices(objs, pids.size()) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    auto pidsItr = pids.begin();
+    for(unsigned int i = 0; i < pids.size(); i++, pidsItr++) 
+        verticesByPID[*pidsItr] = (*objs)[i];
+
+    return S_OK;
+}
+
 HRESULT Mesh::create(Surface **obj){ 
     isDirty = true;
     if(_solver) 
@@ -340,12 +422,38 @@ HRESULT Mesh::create(Surface **obj){
     return S_OK;
 }
 
+HRESULT Mesh::create(Surface*** objs, const size_t& numObjs) {
+    isDirty = true;
+    if(_solver) 
+        _solver->setDirty(true);
+
+    if(allocateSurfaces(objs, numObjs) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
 HRESULT Mesh::create(Body **obj){ 
     isDirty = true;
     if(_solver) 
         _solver->setDirty(true);
 
     if(allocateBody(obj) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
+HRESULT Mesh::create(Body*** objs, const size_t& numObjs) {
+    isDirty = true;
+    if(_solver) 
+        _solver->setDirty(true);
+
+    if(allocateBodies(objs, numObjs) != S_OK) {
         TF_Log(LOG_ERROR);
         return E_FAIL;
     }
@@ -452,12 +560,12 @@ HRESULT Mesh::remove(Vertex *v) {
     isDirty = true;
 
     if(Mesh_checkStoredObj(v) != S_OK) {
-        TF_Log(LOG_ERROR) << "Invalid mesh object passed for remove.";
+        TF_Log(LOG_ERROR) << TF_INVALIDOBJRM_MSG;
         return E_FAIL;
     } 
 
     TF_MESH_OBJINVCHECK(v, vertices->size());
-    std::vector<Surface*> children = v->getSurfaces();
+    auto& children = v->getSurfaces();
     this->vertexIdsAvail.insert(v->_objId);
     if(v->pid >= 0) {
         auto itr = verticesByPID.find(v->pid);
@@ -481,11 +589,99 @@ HRESULT Mesh::remove(Vertex *v) {
     return S_OK;
 }
 
+HRESULT Mesh::remove(Vertex** v, const size_t& numObjs) {
+    isDirty = true;
+
+    // check objects and get children, vertex ids and particle ids
+
+    const size_t nObjs = vertices->size();
+    std::vector<HRESULT> statusPool(ThreadPool::size(), S_OK);
+    std::vector<std::unordered_set<Surface*> > childrenPool(ThreadPool::size());
+    std::vector<std::unordered_set<unsigned int> > idsToMakeAvailPool(ThreadPool::size());
+    std::vector<std::unordered_set<int> > pidsToErasePool(ThreadPool::size());
+    auto& this_verticesByPID = this->verticesByPID;
+    parallel_for(
+        ThreadPool::size(), 
+        [&v, &numObjs, &statusPool, &nObjs, &childrenPool, &idsToMakeAvailPool, &pidsToErasePool, &this_verticesByPID](int tid) -> void {
+            HRESULT& statusThread = statusPool[tid];
+            std::unordered_set<Surface*>& childrenThread = childrenPool[tid];
+            std::unordered_set<unsigned int>& idsToMakeAvailThread = idsToMakeAvailPool[tid];
+            std::unordered_set<int>& pidsToEraseThread = pidsToErasePool[tid];
+            for(int i = tid; i < numObjs; i += ThreadPool::size()) {
+                Vertex* obj = v[i];
+                if(TF_MESH_OBJCHECK(obj) || TF_MESH_OBJINVSIZECHECK(obj, nObjs)) {
+                    statusThread = E_FAIL;
+                    return;
+                }
+                for(auto& c : obj->getSurfaces()) 
+                    childrenThread.insert(c);
+                idsToMakeAvailThread.insert(obj->_objId);
+                auto itr = this_verticesByPID.find(obj->pid);
+                if(itr != this_verticesByPID.end()) 
+                    pidsToEraseThread.insert(obj->pid);
+            }
+        }
+    );
+    for(auto& statusThread : statusPool) 
+        if(statusThread) {
+            TF_Log(LOG_ERROR) << TF_INVALIDOBJRM_MSG;
+            return E_FAIL;
+        }
+
+    size_t numChildren = 0;
+    for(auto& childrenThread : childrenPool) 
+        numChildren += childrenThread.size();
+    std::unordered_set<Surface*> children;
+    children.reserve(numChildren);
+    for(auto& childrenThread : childrenPool) 
+        for(auto& c : childrenThread) 
+            children.insert(c);
+    std::vector<Surface*> childrenVec(children.begin(), children.end());
+
+    // make ids available and remove particle id mappings
+    
+    for(auto& idsToMakeAvailThread : idsToMakeAvailPool) 
+        this->vertexIdsAvail.insert(idsToMakeAvailThread.begin(), idsToMakeAvailThread.end());
+    for(auto& pidsToEraseThread : pidsToErasePool) 
+        for(auto& pid : pidsToEraseThread) 
+            this->verticesByPID.erase(pid);
+
+    // notify quality
+
+    if(_quality) 
+        for(auto& idsToMakeAvailThread : idsToMakeAvailPool) 
+            for(auto& objId : idsToMakeAvailThread) 
+                _quality->includeVertex(objId);
+
+    // clear objects
+
+    auto& this_objs = *(this->vertices);
+    parallel_for(numObjs, [&this_objs, &v](int i) -> void { this_objs[v[i]->_objId] = Vertex(); } );
+    nr_vertices -= numObjs;
+
+    // log
+
+    if(_solver) 
+        for(unsigned int i = 0; i < numObjs; i++) {
+            auto obj = v[i];
+            _solver->log(MeshLogEventType::Destroy, {obj->_objId}, {obj->objType()});
+        }
+
+    // remove children
+
+    if(remove(childrenVec.data(), childrenVec.size()) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
 HRESULT Mesh::remove(Surface *s) {
     isDirty = true;
 
     if(Mesh_checkStoredObj(s) != S_OK) {
-        TF_Log(LOG_ERROR) << "Invalid mesh object passed for remove.";
+        TF_Log(LOG_ERROR) << TF_INVALIDOBJRM_MSG;
         return E_FAIL;
     } 
 
@@ -511,11 +707,122 @@ HRESULT Mesh::remove(Surface *s) {
     return S_OK;
 }
 
+HRESULT Mesh::remove(Surface** s, const size_t& numObjs) {
+    isDirty = true;
+
+    // check objects, get children, ids and surfaces by vertex
+
+    const size_t nObjs = surfaces->size();
+    std::vector<HRESULT> statusPool(ThreadPool::size(), S_OK);
+    std::vector<std::unordered_set<Vertex*> > verticesPool(ThreadPool::size());
+    std::vector<std::unordered_set<Body*> > childrenPool(ThreadPool::size());
+    std::vector<std::unordered_set<unsigned int> > idsToMakeAvailPool(ThreadPool::size());
+    std::vector<std::unordered_map<Vertex*, std::unordered_set<Surface*> > > surfacesByVerticesPool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&s, &numObjs, &nObjs, &statusPool, &verticesPool, &childrenPool, &idsToMakeAvailPool, &surfacesByVerticesPool](int tid) -> void {
+            HRESULT& statusThread = statusPool[tid];
+            std::unordered_set<Vertex*>& verticesThread = verticesPool[tid];
+            std::unordered_set<Body*>& childrenThread = childrenPool[tid];
+            std::unordered_set<unsigned int>& idsToMakeAvailThread = idsToMakeAvailPool[tid];
+            std::unordered_map<Vertex*, std::unordered_set<Surface*> >& surfacesByVerticesThread = surfacesByVerticesPool[tid];
+            for(int i = tid; i < numObjs; i += ThreadPool::size()) {
+                Surface* obj = s[i];
+                if(TF_MESH_OBJCHECK(obj) || TF_MESH_OBJINVSIZECHECK(obj, nObjs)) {
+                    statusThread = E_FAIL;
+                    return;
+                }
+                for(auto& c : obj->getBodies()) 
+                    childrenThread.insert(c);
+                idsToMakeAvailThread.insert(obj->_objId);
+                for(auto& v : obj->getVertices()) {
+                    verticesThread.insert(v);
+                    surfacesByVerticesThread[v].insert(obj);
+                }
+            }
+        }
+    );
+    for(auto& statusThread : statusPool) 
+        if(statusThread != S_OK) {
+            TF_Log(LOG_ERROR) << TF_INVALIDOBJRM_MSG;
+            return E_FAIL;
+        }
+
+    size_t numChildren = 0;
+    for(auto& childrenThread : childrenPool) 
+        numChildren += childrenThread.size();
+    std::unordered_set<Body*> children;
+    children.reserve(numChildren);
+    for(auto& childrenThread : childrenPool) 
+        children.insert(childrenThread.begin(), childrenThread.end());
+    std::vector<Body*> childrenVec(children.begin(), children.end());
+
+    size_t numVertices = 0;
+    for(auto& verticesThread : verticesPool) 
+        numVertices += verticesThread.size();
+    std::unordered_set<Vertex*> vertices;
+    vertices.reserve(numVertices);
+    for(auto& verticesThread : verticesPool) 
+        vertices.insert(verticesThread.begin(), verticesThread.end());
+    std::vector<Vertex*> verticesVec(vertices.begin(), vertices.end());
+
+    std::unordered_map<Vertex*, std::unordered_set<Surface*> > surfacesByVertices;
+    for(auto& surfacesByVerticesThread : surfacesByVerticesPool) 
+        for(auto& p : surfacesByVerticesThread) 
+            surfacesByVertices[p.first].insert(p.second.begin(), p.second.end());
+
+    // remove surfaces from vertices
+
+    parallel_for(
+        verticesVec.size(), 
+        [&verticesVec, &surfacesByVertices](int i) -> void {
+            Vertex* v = verticesVec[i];
+            for(auto& s : surfacesByVertices[v]) 
+                v->remove(s);
+        }
+    );
+
+    // make ids available
+    
+    for(auto& idsToMakeAvailThread : idsToMakeAvailPool) 
+        this->surfaceIdsAvail.insert(idsToMakeAvailThread.begin(), idsToMakeAvailThread.end());
+
+    // notify quality
+
+    if(_quality) 
+        for(auto& idsToMakeAvailThread : idsToMakeAvailPool) 
+            for(auto& objId : idsToMakeAvailThread) 
+                _quality->includeSurface(objId);
+
+    // clear objects
+
+    auto& this_objs = *(this->surfaces);
+    parallel_for(numObjs, [&this_objs, &s](int i) -> void { this_objs[s[i]->_objId] = Surface(); } );
+    nr_surfaces -= numObjs;
+
+    // log
+
+    if(_solver) 
+        for(unsigned int i = 0; i < numObjs; i++) {
+            auto obj = s[i];
+            _solver->log(MeshLogEventType::Destroy, {obj->_objId}, {obj->objType()});
+        }
+
+    // remove children
+
+    if(remove(childrenVec.data(), childrenVec.size()) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return E_FAIL;
+    }
+
+    return S_OK;
+}
+
 HRESULT Mesh::remove(Body *b) {
     isDirty = true;
 
     if(Mesh_checkStoredObj(b) != S_OK) {
-        TF_Log(LOG_ERROR) << "Invalid mesh object passed for remove.";
+        TF_Log(LOG_ERROR) << TF_INVALIDOBJRM_MSG;
         return E_FAIL;
     } 
 
@@ -530,6 +837,97 @@ HRESULT Mesh::remove(Body *b) {
 
     if(_solver)
         _solver->log(MeshLogEventType::Destroy, {b->_objId}, {b->objType()});
+
+    return S_OK;
+}
+
+HRESULT Mesh::remove(Body** b, const size_t& numObjs) {
+    isDirty = true;
+
+    // check objects, get surfaces and bodies by surface
+
+    const size_t nObjs = bodies->size();
+    std::vector<HRESULT> statusPool(ThreadPool::size(), S_OK);
+    std::vector<std::unordered_set<Surface*> > surfacesPool(ThreadPool::size());
+    std::vector<std::unordered_set<unsigned int> > idsToMakeAvailPool(ThreadPool::size());
+    std::vector<std::unordered_map<Surface*, std::unordered_set<Body*> > > bodiesBySurfacePool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&b, &numObjs, &nObjs, &statusPool, &surfacesPool, &idsToMakeAvailPool, &bodiesBySurfacePool](int tid) -> void {
+            HRESULT& statusThread = statusPool[tid];
+            std::unordered_set<Surface*>& surfacesThread = surfacesPool[tid];
+            std::unordered_set<unsigned int>& idsToMakeAvailThread = idsToMakeAvailPool[tid];
+            std::unordered_map<Surface*, std::unordered_set<Body*> >& bodiesBySurfaceThread = bodiesBySurfacePool[tid];
+            for(int i = tid; i < numObjs; i += ThreadPool::size()) {
+                Body* obj = b[i];
+                if(TF_MESH_OBJCHECK(obj) || TF_MESH_OBJINVSIZECHECK(obj, nObjs)) {
+                    statusThread = E_FAIL;
+                    return;
+                }
+                idsToMakeAvailThread.insert(obj->_objId);
+                for(auto& s : obj->getSurfaces()) {
+                    surfacesThread.insert(s);
+                    bodiesBySurfaceThread[s].insert(obj);
+                }
+            }
+        }
+    );
+    for(auto& statusThread : statusPool) 
+        if(statusThread != S_OK) {
+            TF_Log(LOG_ERROR) << TF_INVALIDOBJRM_MSG;
+            return E_FAIL;
+        }
+
+    size_t numSurfaces = 0;
+    for(auto& surfacesThread : surfacesPool) 
+        numSurfaces += surfacesThread.size();
+    std::unordered_set<Surface*> surfaces;
+    surfaces.reserve(numSurfaces);
+    for(auto& surfacesThread : surfacesPool) 
+        surfaces.insert(surfacesThread.begin(), surfacesThread.end());
+    std::vector<Surface*> surfacesVec(surfaces.begin(), surfaces.end());
+
+    std::unordered_map<Surface*, std::unordered_set<Body*> > bodiesBySurface;
+    for(auto& bodiesBySurfaceThread : bodiesBySurfacePool) 
+        for(auto& p : bodiesBySurfaceThread) 
+            bodiesBySurface[p.first].insert(p.second.begin(), p.second.end());
+
+    // remove bodies from surfaces
+
+    parallel_for(
+        surfaces.size(), 
+        [&surfacesVec, &bodiesBySurface](int i) -> void {
+            Surface* s = surfacesVec[i];
+            for(auto& b : bodiesBySurface[s]) 
+                s->remove(b);
+        }
+    );
+
+    // make ids available
+    
+    for(auto& idsToMakeAvailThread : idsToMakeAvailPool) 
+        this->bodyIdsAvail.insert(idsToMakeAvailThread.begin(), idsToMakeAvailThread.end());
+
+    // notify quality
+
+    if(_quality) 
+        for(auto& idsToMakeAvailThread : idsToMakeAvailPool) 
+            for(auto& objId : idsToMakeAvailThread) 
+                _quality->includeBody(objId);
+
+    // clear objects
+
+    auto& this_objs = *(this->bodies);
+    parallel_for(numObjs, [&this_objs, &b](int i) -> void { this_objs[b[i]->_objId] = Body(); } );
+    nr_bodies -= numObjs;
+
+    // log
+
+    if(_solver) 
+        for(unsigned int i = 0; i < numObjs; i++) {
+            auto obj = b[i];
+            _solver->log(MeshLogEventType::Destroy, {obj->_objId}, {obj->objType()});
+        }
 
     return S_OK;
 }

--- a/source/models/vertex/solver/tfMesh.h
+++ b/source/models/vertex/solver/tfMesh.h
@@ -71,6 +71,9 @@ namespace TissueForge::models::vertex {
         HRESULT allocateVertex(Vertex **obj);
         HRESULT allocateSurface(Surface **obj);
         HRESULT allocateBody(Body **obj);
+        HRESULT allocateVertices(Vertex*** objs, const size_t& numObjs);
+        HRESULT allocateSurfaces(Surface*** objs, const size_t& numObjs);
+        HRESULT allocateBodies(Body*** objs, const size_t& numObjs);
 
     public:
 
@@ -144,6 +147,14 @@ namespace TissueForge::models::vertex {
         HRESULT create(Vertex **obj, const unsigned int &pid);
 
         /**
+         * @brief Create vertices
+         * 
+         * @param objs vertices to populate
+         * @param pids the ids of the underlying particles
+         */
+        HRESULT create(Vertex*** objs, const std::vector<unsigned int>& pids);
+
+        /**
          * @brief Create a surface
          * 
          * @param obj a surface to populate
@@ -151,11 +162,27 @@ namespace TissueForge::models::vertex {
         HRESULT create(Surface **obj);
 
         /**
+         * @brief Create surfaces
+         * 
+         * @param objs surfaces to populate
+         * @param numObjs number of surfaces
+         */
+        HRESULT create(Surface*** objs, const size_t& numObjs);
+
+        /**
          * @brief Create a body
          * 
          * @param obj a body to populate
          */
         HRESULT create(Body **obj);
+
+        /**
+         * @brief Create bodies
+         * 
+         * @param objs bodies to populate
+         * @param numObjs number of bodies
+         */
+        HRESULT create(Body*** objs, const size_t& numObjs);
 
         /**
          * @brief Get the mesh
@@ -286,6 +313,14 @@ namespace TissueForge::models::vertex {
         HRESULT remove(Vertex *v);
 
         /**
+         * @brief Remove vertices from the mesh; all dependent surfaces and bodies are also removed
+         * 
+         * @param v vertices
+         * @param numObjs number of vertices
+         */
+        HRESULT remove(Vertex** v, const size_t& numObjs);
+
+        /**
          * @brief Remove a surface from the mesh; all dependent bodies are also removed
          * 
          * @param s a surface
@@ -293,11 +328,27 @@ namespace TissueForge::models::vertex {
         HRESULT remove(Surface *s);
 
         /**
+         * @brief Remove surfaces from the mesh; all dependent bodies are also removed
+         * 
+         * @param s surfaces
+         * @param numObjs number of surfaces
+         */
+        HRESULT remove(Surface** s, const size_t& numObjs);
+
+        /**
          * @brief Remove a body from the mesh
          * 
          * @param b a body
          */
         HRESULT remove(Body *b);
+
+        /**
+         * @brief Remove bodies from the mesh
+         * 
+         * @param b bodies
+         * @param numObjs number of bodies
+         */
+        HRESULT remove(Body** b, const size_t& numObjs);
 
         /**
          * @brief Test whether the mesh is 3D. 

--- a/source/models/vertex/solver/tfMeshSolver.cpp
+++ b/source/models/vertex/solver/tfMeshSolver.cpp
@@ -608,7 +608,7 @@ bool MeshSolver::_isDirtyInst() const {
 }
 
 bool MeshSolver::isDirty() {
-    TF_MESHSOLVER_CHECKINIT
+    TF_MESHSOLVER_CHECKINIT_RET(false);
 
     return _solver->_isDirtyInst();
 }

--- a/source/models/vertex/solver/tfSurface.cpp
+++ b/source/models/vertex/solver/tfSurface.cpp
@@ -37,6 +37,8 @@
 #include <tf_util.h>
 #include <io/tfIO.h>
 #include <io/tfFIO.h>
+#include <tfTaskScheduler.h>
+#include <tf_metrics.h>
 
 #include <io/tfThreeDFVertexData.h>
 #include <io/tfThreeDFEdgeData.h>
@@ -113,7 +115,65 @@ static HRESULT Surface_fromVertices(Surface *s, std::vector<Vertex*> vertices) {
     return S_OK;
 }
 
-static Surface *Surface_create(std::vector<Vertex*> _vertices) {
+static HRESULT Surfaces_fromVertices(Surface **s, std::vector<std::vector<Vertex*> > vertices) {
+    Surface_GETMESH(mesh, E_FAIL);
+
+    std::vector<HRESULT> resultPool(ThreadPool::size(), S_OK);
+    std::vector<std::unordered_map<Vertex*, std::unordered_set<Surface*> > > toAddSurfacesByVertexPool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&s, &vertices, &mesh, &resultPool, &toAddSurfacesByVertexPool](int tid) -> void {
+            HRESULT& resultThread = resultPool[tid];
+            std::unordered_map<Vertex*, std::unordered_set<Surface*> >& toAddSurfacesByVertexThread = toAddSurfacesByVertexPool[tid];
+
+            for(int i = tid; i < vertices.size(); i += ThreadPool::size()) {
+                std::vector<Vertex*>& vertices_i = vertices[i];
+                Surface* si = s[i];
+                if(vertices_i.size() < 3) {
+                    resultThread = E_FAIL;
+                    return;
+                }
+                else {
+                    for(auto& v : vertices_i) {
+                        si->add(v);
+                        toAddSurfacesByVertexThread[v].insert(si);
+                    }
+                }
+            }
+        }
+    );
+    for(auto& resultThread : resultPool) 
+        if(resultThread != S_OK) {
+            return tf_error(resultThread, "Surfaces require at least 3 vertices");
+        }
+
+    std::unordered_map<Vertex*, std::unordered_set<Surface*> > toAddSurfacesByVertex;
+    for(auto& toAddSurfacesByVertexThread : toAddSurfacesByVertexPool) {
+        for(auto& m : toAddSurfacesByVertexThread) 
+            toAddSurfacesByVertex[m.first].insert(m.second.begin(), m.second.end());
+    }
+    std::vector<Vertex*> verticesFlat;
+    verticesFlat.reserve(toAddSurfacesByVertex.size());
+    for(auto& m : toAddSurfacesByVertex) 
+        verticesFlat.push_back(m.first);
+    parallel_for(
+        verticesFlat.size(), 
+        [&verticesFlat, &toAddSurfacesByVertex](int i) -> void {
+            Vertex* v = verticesFlat[i];
+            for(auto& s : toAddSurfacesByVertex[v]) 
+                v->add(s);
+        }
+    );
+
+    parallel_for(
+        vertices.size(), 
+        [&vertices](int i) -> void { for(auto& v : vertices[i]) v->updateConnectedVertices(); }
+    );
+
+    return S_OK;
+}
+
+static Surface *Surface_create(const std::vector<Vertex*>& _vertices) {
     Surface_GETMESH(mesh, NULL);
 
     Surface *result;
@@ -126,6 +186,23 @@ static Surface *Surface_create(std::vector<Vertex*> _vertices) {
         return NULL;
     }
     result->positionChanged();
+    return result;
+}
+
+static std::vector<Surface*> Surfaces_create(const std::vector<std::vector<Vertex*> >& _vertices) {
+    Surface_GETMESH(mesh, {});
+
+    std::vector<Surface*> result(_vertices.size());
+    Surface** data = result.data();
+    if(mesh->create(&data, _vertices.size()) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+    if(Surfaces_fromVertices(data, _vertices) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+    parallel_for(result.size(), [&result](int i) -> void { result[i]->positionChanged(); });
     return result;
 }
 
@@ -144,6 +221,39 @@ static Surface *Surface_create(const std::vector<VertexHandle> &_vertices) {
     }
 
     return Surface_create(_vertices_objs);
+}
+
+static std::vector<Surface*> Surfaces_create(const std::vector<std::vector<VertexHandle> >& _vertices) {
+    std::vector<std::vector<Vertex*> > _vertices_objs(_vertices.size());
+    std::vector<HRESULT> resultPool(ThreadPool::size(), S_OK);
+
+    parallel_for(
+        ThreadPool::size(), 
+        [&_vertices, &_vertices_objs, &resultPool](int tid) -> void {
+            HRESULT& resultThread = resultPool[tid];
+            for(unsigned int i = tid; i < _vertices.size(); i += ThreadPool::size()) {
+                const std::vector<VertexHandle>& _vertices_i = _vertices[i];
+                std::vector<Vertex*>& _vertices_objs_i = _vertices_objs[i];
+                _vertices_objs_i.reserve(_vertices_i.size());
+                for(auto& v : _vertices_i) {
+                    Vertex* _v = v.vertex();
+                    if(!_v) {
+                        resultThread = E_FAIL;
+                        return;
+                    }
+                    _vertices_objs_i.push_back(_v);
+                }
+            }
+        }
+    );
+
+    for(auto& resultThread : resultPool) 
+        if(resultThread != S_OK) {
+            TF_Log(LOG_ERROR);
+            return {};
+        }
+
+    return Surfaces_create(_vertices_objs);
 }
 
 SurfaceHandle Surface::create(const std::vector<VertexHandle> &_vertices) {
@@ -215,6 +325,71 @@ SurfaceHandle Surface::create(TissueForge::io::ThreeDFFaceData *face) {
     }
 
     return create(_vertices);
+}
+
+std::vector<SurfaceHandle> Surface::create(const std::vector<std::vector<VertexHandle> >& _vertices) {
+    std::vector<Surface*> _result = Surfaces_create(_vertices);
+    if(_result.empty()) 
+        return {};
+
+    std::vector<SurfaceHandle> result(_result.size());
+    parallel_for(result.size(), [&_result, &result](int i) -> void { result[i] = SurfaceHandle(_result[i]->_objId); });
+
+    return result;
+}
+
+std::vector<SurfaceHandle> Surface::create(const std::vector<TissueForge::io::ThreeDFFaceData*> &_faces) {
+    if(_faces.empty()) 
+        return {};
+
+    std::vector<std::vector<TissueForge::io::ThreeDFVertexData*> > verticesByFace(_faces.size());
+    std::vector<std::unordered_set<TissueForge::io::ThreeDFVertexData*> > verticesFlatPool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&_faces, &verticesByFace, &verticesFlatPool](int tid) -> void {
+            std::unordered_set<TissueForge::io::ThreeDFVertexData*>& verticesFlatThread = verticesFlatPool[tid];
+            for(unsigned int i = tid; i < _faces.size(); i += ThreadPool::size()) {
+                std::vector<TissueForge::io::ThreeDFVertexData*>& vverts = verticesByFace[i];
+                Surface_order3DFFaceVertices(_faces[i], vverts);
+                for(auto& v : vverts) 
+                    verticesFlatThread.insert(v);
+            }
+        }
+    );
+    std::unordered_set<TissueForge::io::ThreeDFVertexData*> verticesFlatSet;
+    size_t numVertices = 0;
+    for(auto& verticesFlatThread : verticesFlatPool) 
+        verticesFlatSet.insert(verticesFlatThread.begin(), verticesFlatThread.end());
+    std::vector<TissueForge::io::ThreeDFVertexData*> verticesFlat(verticesFlatSet.begin(), verticesFlatSet.end());
+
+    std::vector<VertexHandle> newVertices = Vertex::create(verticesFlat);
+    std::unordered_map<unsigned int, unsigned int> newVerticesMap;
+
+    parallel_for(
+        verticesFlat.size(), 
+        [&verticesFlat, &newVertices, &newVerticesMap](int i) -> void { newVerticesMap[verticesFlat[i]->id] = i; }
+    );
+
+    std::vector<std::vector<Vertex*> > vertices(_faces.size());
+    parallel_for(
+        _faces.size(), 
+        [&verticesByFace, &vertices, &newVertices, &newVerticesMap](int i) -> void {
+            std::vector<TissueForge::io::ThreeDFVertexData*> vverts = verticesByFace[i];
+            std::vector<Vertex*>& verts = vertices[i];
+            verts.reserve(vverts.size());
+            for(auto& vv : vverts) 
+                verts.push_back(newVertices[newVerticesMap[vv->id]].vertex());
+        }
+    );
+
+    std::vector<Surface*> _result = Surfaces_create(vertices);
+    std::vector<SurfaceHandle> result(_result.size());
+    parallel_for(
+        _result.size(), 
+        [&result, &_result](int i) -> void { result[i] = SurfaceHandle(_result[i]->_objId); }
+    );
+
+    return result;
 }
 
 bool Surface::defines(const Body *obj) const { MESHBOJ_DEFINES_DEF(getSurfaces) }
@@ -358,7 +533,7 @@ HRESULT Surface::destroy() {
         return E_FAIL;
     if(this->typeId >= 0 && this->type()->remove(SurfaceHandle(this->_objId)) != S_OK) 
         return E_FAIL;
-    std::vector<Vertex*> affectedVertices = getVertices();
+    auto& affectedVertices = getVertices();
     if(this->_objId >= 0) 
         Mesh::get()->remove(this);
     for(auto &v : affectedVertices) 
@@ -367,7 +542,7 @@ HRESULT Surface::destroy() {
 }
 
 HRESULT Surface::destroy(Surface *target) {
-    auto vertices = target->getVertices();
+    auto& vertices = target->getVertices();
 
     std::unordered_set<Vertex*> affectedVertices;
     for(auto &v : vertices) 
@@ -397,6 +572,131 @@ HRESULT Surface::destroy(SurfaceHandle &target) {
     if(res == S_OK) 
         target.id = -1;
     return res;
+}
+
+HRESULT Surface::destroy(const std::vector<Surface*>& target) {
+    // Filter valid targets and get all vertices, bodies and surface types associated with all removed surfaces
+
+    std::vector<std::unordered_set<Surface*> > surfacesToDestroyPool(ThreadPool::size());
+    std::vector<std::unordered_set<Vertex*> > verticesPool(ThreadPool::size());
+    std::vector<std::unordered_set<Body*> > bodiesPool(ThreadPool::size());
+    std::vector<std::unordered_set<SurfaceType*> > surfaceTypesPool(ThreadPool::size());
+    std::vector<std::unordered_map<SurfaceType*, std::unordered_set<Surface*> > > surfacesByTypePool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&target, &surfacesToDestroyPool, &verticesPool, &bodiesPool, &surfaceTypesPool, &surfacesByTypePool](int tid) -> void {
+            std::unordered_set<Surface*>& surfacesToDestroyThread = surfacesToDestroyPool[tid];
+            std::unordered_set<Vertex*>& verticesThread = verticesPool[tid];
+            std::unordered_set<Body*>& bodiesThread = bodiesPool[tid];
+            std::unordered_set<SurfaceType*>& surfaceTypesThread = surfaceTypesPool[tid];
+            std::unordered_map<SurfaceType*, std::unordered_set<Surface*> >& surfacesByTypeThread = surfacesByTypePool[tid];
+            for(int i = tid; i < target.size(); i += ThreadPool::size()) {
+                Surface* s = target[i];
+                if(s && s->_objId >= 0) {
+                    surfacesToDestroyThread.insert(s);
+                    for(auto& v : s->getVertices()) 
+                        if(v->getSurfaces().size() == 1) 
+                            verticesThread.insert(v);
+                    for(auto& b : s->getBodies()) 
+                        bodiesThread.insert(b);
+                    if(s->typeId >= 0) {
+                        SurfaceType* stype = s->type();
+                        surfaceTypesThread.insert(stype);
+                        surfacesByTypeThread[stype].insert(s);
+                    }
+                }
+            }
+        }
+    );
+    size_t numSurfaces = 0;
+    for(auto& surfacesToDestroyThread : surfacesToDestroyPool) 
+        numSurfaces += surfacesToDestroyThread.size();
+    std::unordered_set<Surface*> surfacesToDestroy;
+    surfacesToDestroy.reserve(numSurfaces);
+    for(auto& surfacesToDestroyThread : surfacesToDestroyPool) 
+        surfacesToDestroy.insert(surfacesToDestroyThread.begin(), surfacesToDestroyThread.end());
+    std::vector<Surface*> surfacesToDestroyVec(surfacesToDestroy.begin(), surfacesToDestroy.end());
+
+    size_t numVertices = 0;
+    for(auto& verticesThread : verticesPool) 
+        numVertices += verticesThread.size();
+    std::unordered_set<Vertex*> vertices;
+    vertices.reserve(numVertices);
+    for(auto& verticesThread : verticesPool) 
+        for(auto& v : verticesThread) 
+            vertices.insert(v);
+    std::vector<Vertex*> verticesVec(vertices.begin(), vertices.end());
+
+    // get all vertices affected by removing the surfaces
+
+    std::vector<std::unordered_set<Vertex*> > affectedVerticesPool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&verticesVec, &surfacesToDestroyVec, &affectedVerticesPool](int tid) -> void {
+            std::unordered_set<Vertex*>& affectedVerticesThread = affectedVerticesPool[tid];
+            for(int i = tid; i < surfacesToDestroyVec.size(); i += ThreadPool::size()) 
+                for(auto& v : surfacesToDestroyVec[i]->getVertices()) 
+                    for(auto& nv : v->connectedVertices()) 
+                        if(std::find(verticesVec.begin(), verticesVec.end(), nv) == verticesVec.end()) 
+                            affectedVerticesThread.insert(nv);
+        }
+    );
+    numVertices = 0;
+    for(auto& affectedVerticesThread : affectedVerticesPool) 
+        numVertices += affectedVerticesThread.size();
+    std::unordered_set<Vertex*> affectedVertices;
+    affectedVertices.reserve(numVertices);
+    for(auto& affectedVerticesThread : affectedVerticesPool) 
+        affectedVertices.insert(affectedVerticesThread.begin(), affectedVerticesThread.end());
+
+    // destroy dependent bodies
+
+    size_t numBodies = 0;
+    for(auto& bodiesThread : bodiesPool) 
+        numBodies += bodiesThread.size();
+    std::unordered_set<Body*> bodies;
+    bodies.reserve(numBodies);
+    for(auto& bodiesThread : bodiesPool) 
+        for(auto& b : bodiesThread) 
+            bodies.insert(b);
+    Body::destroy({bodies.begin(), bodies.end()});
+
+    // remove from types
+
+    size_t numSurfaceTypes = 0;
+    for(auto& surfaceTypesThread : surfaceTypesPool) 
+        numSurfaceTypes += surfaceTypesThread.size();
+    std::unordered_set<SurfaceType*> surfaceTypes;
+    surfaceTypes.reserve(numSurfaceTypes);
+    for(auto& surfaceTypesThread : surfaceTypesPool) 
+        surfaceTypes.insert(surfaceTypesThread.begin(), surfaceTypesThread.end());
+    std::unordered_map<SurfaceType*, size_t> numSurfacesByType;
+    for(auto& stype : surfaceTypes) {
+        size_t& nSurfaces = numSurfacesByType[stype];
+        for(auto& surfacesByTypeThread : surfacesByTypePool) 
+            nSurfaces += surfacesByTypeThread[stype].size();
+    }
+    std::unordered_map<SurfaceType*, std::unordered_set<SurfaceHandle> > surfacesByType;
+    for(auto& stype : surfaceTypes) {
+        std::unordered_set<SurfaceHandle>& thisSurfacesByType = surfacesByType[stype];
+        thisSurfacesByType.reserve(numSurfacesByType[stype]);
+        for(auto& surfacesByTypeThread : surfacesByTypePool) 
+            for(auto& s : surfacesByTypeThread[stype]) 
+                thisSurfacesByType.emplace(s->objectId());
+        stype->remove({thisSurfacesByType.begin(), thisSurfacesByType.end()});
+    }
+
+    // destroy the surfaces
+    Mesh::get()->remove(surfacesToDestroyVec.data(), surfacesToDestroyVec.size());
+
+    // destroy the vertices that have no remaining surfaces
+    Mesh::get()->remove(verticesVec.data(), verticesVec.size());
+
+    // update connectedness of the affected vertices
+    std::vector<Vertex*> affectedVerticesVec(affectedVertices.begin(), affectedVertices.end());
+    parallel_for(affectedVerticesVec.size(), [&affectedVerticesVec](int i) -> void { affectedVerticesVec[i]->updateConnectedVertices(); });
+
+    return S_OK;
 }
 
 bool Surface::validate() {
@@ -553,8 +853,18 @@ std::tuple<Vertex*, Vertex*> Surface::neighborVertices(const Vertex *v) const {
 
     auto itr = std::find(vertices.begin(), vertices.end(), v);
     if(itr != vertices.end()) {
-        vp = itr + 1 == vertices.end() ? *vertices.begin()     : *(itr + 1);
-        vn = itr == vertices.begin()   ? *(vertices.end() - 1) : *(itr - 1);
+        if(itr == vertices.begin()) {
+            vp = *(itr + 1);
+            vn = *(vertices.end() - 1);
+        }
+        else if(itr + 1 == vertices.end()) {
+            vp = *vertices.begin();
+            vn = *(itr - 1);
+        }
+        else {
+            vp = *(itr + 1);
+            vn = *(itr - 1);
+        }
     }
 
     return std::make_tuple(vp, vn);
@@ -791,28 +1101,20 @@ HRESULT Surface::positionChanged() {
     return S_OK;
 }
 
-HRESULT Surface::sew(Surface *s1, Surface *s2, const FloatP_t &distCf) {
-    if(s1->objectId() == s2->objectId()) 
-        return S_OK;
+bool Surface::testSew(Surface* s1, Surface* s2, const FloatP_t& distCf, std::vector<int>& indicesMatched) {
+    indicesMatched = std::vector<int>(s1->vertices.size(), -1);
 
-    for(auto &v : s1->vertices) 
-        if(v->positionChanged() != S_OK) 
-            return E_FAIL;
-    for(auto &v : s2->vertices) 
-        if(v->positionChanged() != S_OK) 
-            return E_FAIL;
-    if(s1->positionChanged() != S_OK || s2->positionChanged() != S_OK) 
-        return E_FAIL;
-
-    // Pre-calculate vertex positions
-    std::vector<FVector3> s2_positions;
-    s2_positions.reserve(s2->vertices.size());
-    for(auto &v : s2->vertices) 
-        s2_positions.push_back(v->getPosition());
+    // Pre-calculate info
+    std::vector<std::pair<unsigned int, FVector3> > s2_positions_filtered;
+    s2_positions_filtered.reserve(s2->vertices.size());
+    for(unsigned int i = 0; i < s2->vertices.size(); i++) {
+        Vertex* v = s2->vertices[i];
+        if(!v->defines(s1)) 
+            s2_positions_filtered.push_back({i, v->getPosition()});
+    }
 
     // Find vertices to merge
-    FloatP_t distCrit2 = distCf * distCf * 0.5 * (s1->area + s2->area);
-    std::vector<int> indicesMatched(s1->vertices.size(), -1);
+    const FloatP_t distCrit2 = distCf * distCf * 0.5 * (s1->area + s2->area);
     std::vector<FloatP_t> dist2Matched(s1->vertices.size(), distCrit2);
     size_t numMatched = 0;
     for(int i = 0; i < s1->vertices.size(); i++) {
@@ -823,10 +1125,12 @@ HRESULT Surface::sew(Surface *s1, Surface *s2, const FloatP_t &distCf) {
         auto posi = vi->getPosition();
         FloatP_t minDist2 = distCrit2;
         int matchedIdx = -1;
-        for(int j = 0; j < s2->vertices.size(); j++) { 
-            Vertex *vj = s2->vertices[j];
-            auto dist2 = (s2_positions[j] - posi).dot();
-            if(dist2 < minDist2 && !vj->defines(s1)) {
+        for(auto& p : s2_positions_filtered) {
+            unsigned int j;
+            FVector3 posj;
+            std::tie(j, posj) = p;
+            auto dist2 = (posj - posi).dot();
+            if(dist2 < minDist2) {
                 minDist2 = dist2;
                 matchedIdx = j;
             }
@@ -854,11 +1158,27 @@ HRESULT Surface::sew(Surface *s1, Surface *s2, const FloatP_t &distCf) {
             numMatched++;
     }
 
-    if(numMatched == 0) 
+    return numMatched > 0;
+}
+
+HRESULT Surface::sew(Surface *s1, Surface *s2, const FloatP_t &distCf) {
+    for(auto &v : s1->vertices) 
+        if(v->positionChanged() != S_OK) 
+            return E_FAIL;
+    for(auto &v : s2->vertices) 
+        if(v->positionChanged() != S_OK) 
+            return E_FAIL;
+    if(s1->positionChanged() != S_OK || s2->positionChanged() != S_OK) 
+        return E_FAIL;
+
+    // Find vertices to merge
+    std::vector<int> indicesMatched;
+    if(!testSew(s1, s2, distCf, indicesMatched)) 
         return S_OK;
 
     // Merge matched vertices
     std::vector<std::pair<Vertex*, Vertex*> > toMerge;
+    toMerge.reserve(indicesMatched.size());
     for(int i = 0; i < indicesMatched.size(); i++) {
         int vj_idx = indicesMatched[i];
         if(vj_idx >= 0) 
@@ -885,26 +1205,163 @@ HRESULT Surface::sew(const SurfaceHandle &s1, const SurfaceHandle &s2, const Flo
     return Surface::sew(_s1, _s2, distCf);
 }
 
-HRESULT Surface::sew(std::vector<Surface*> _surfaces, const FloatP_t &distCf) {
-    for(std::vector<Surface*>::iterator itri = _surfaces.begin(); itri != _surfaces.end() - 1; itri++) 
-        for(std::vector<Surface*>::iterator itrj = itri + 1; itrj != _surfaces.end(); itrj++) 
-            if(*itri != *itrj && sew(*itri, *itrj, distCf) != S_OK) 
-                return E_FAIL;
-
-    return S_OK;
+template <typename T> 
+void _recursive_set_insert(const std::unordered_map<T, std::unordered_set<T> >& vMap, std::unordered_set<T>& vSet, T v) {
+    vSet.insert(v);
+    auto itr = vMap.find(v);
+    if(itr != vMap.end()) 
+        for(auto& vv : itr->second) 
+            _recursive_set_insert(vMap, vSet, vv);
 }
 
-HRESULT Surface::sew(std::vector<SurfaceHandle> _surfaces, const FloatP_t &distCf) {
-    std::vector<Surface*> surfaces;
-    surfaces.reserve(_surfaces.size());
-    for(auto &_s : _surfaces) {
-        Surface *s = _s.surface();
-        if(!s) {
-            SurfaceHandle_INVALIDHANDLERR;
-            return E_FAIL;
+HRESULT Surface::sew(const std::vector<Surface*>& _surfaces, const FloatP_t &distCf) {
+    // Do the same algorithm as inter-particle interactions, but only on particles underlying vertices
+
+    std::vector<FVector3> sCom(_surfaces.size());
+    std::vector<FloatP_t> sRadii(_surfaces.size(), FPTYPE_ZERO);
+    parallel_for(
+        ThreadPool::size(), 
+        [&_surfaces, &sCom, &sRadii](int tid) -> void {
+            for(int i = tid; i < _surfaces.size(); i += ThreadPool::size()) {
+                Surface* s = _surfaces[i];
+                const FVector3 com = s->getCentroid();
+                FloatP_t maxDist2 = FPTYPE_ZERO;
+                for(auto& v : s->getVertices()) 
+                    maxDist2 = FPTYPE_FMAX(maxDist2, metrics::relativePosition(v->getPosition(), com).dot());
+                sCom[i] = com;
+                sRadii[i] = FPTYPE_SQRT(maxDist2);
+            }
         }
-        surfaces.push_back(s);
-    }
+    );
+
+    std::vector<std::vector<std::pair<unsigned int, unsigned int> > > sewCandidatesPool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&sCom, &sRadii, &_surfaces, &distCf, &sewCandidatesPool](int tid) -> void {
+            std::vector<std::pair<unsigned int, unsigned int> >& sewCandidatesThread = sewCandidatesPool[tid];
+            for(unsigned int i = tid; i < sCom.size() - 1; i += ThreadPool::size()) {
+                Surface* si = _surfaces[i];
+                const FloatP_t siarea = si->getArea();
+                const FVector3 sicom = sCom[i];
+                const FloatP_t siRadius = sRadii[i];
+
+                for(unsigned int j = i + 1; j < sCom.size(); j++) {
+                    Surface* sj = _surfaces[j];
+                    const FVector3 sjcom = sCom[j];
+                    const FloatP_t sjRadius = sRadii[j];
+
+                    const FloatP_t sijDist = siRadius + sjRadius + FPTYPE_SQRT(0.5 * (siarea + sj->getArea())) * distCf;
+
+                    if(metrics::relativePosition(sicom, sjcom).dot() < sijDist * sijDist) 
+                        sewCandidatesThread.push_back({i, j});
+                }
+            }
+        }
+    );
+
+    // Among candidate pairs, the candidate with the lesser id (the primary surface) owns the pair
+    // When the secondary surface of a pair is not the primary surface of any pair, then only removing its vertices is not thread safe
+
+    std::vector<std::vector<unsigned int> > sewCandidateSchedule(_surfaces.size());
+    for(auto& sewCandidatesThread : sewCandidatesPool) 
+        for(auto& p : sewCandidatesThread) {
+            unsigned int si, sj;
+            std::tie(si, sj) = p;
+            sewCandidateSchedule[si].push_back(sj);
+        }
+
+    // Gather vertices that should be merged
+
+    std::vector<std::unordered_map<Vertex*, Vertex*> > toMergePool(ThreadPool::size());
+
+    parallel_for(
+        ThreadPool::size(), 
+        [&toMergePool, &sewCandidateSchedule, &_surfaces, &distCf](int tid) -> void {
+            std::vector<int> indicesMatched;
+            std::unordered_map<Vertex*, Vertex*>& toMergeThread = toMergePool[tid];
+
+            for(int i = tid; i < sewCandidateSchedule.size(); i += ThreadPool::size()) {
+                std::vector<unsigned int>& sewCandidateThread = sewCandidateSchedule[i];
+                Surface* si = _surfaces[i];
+
+                for(auto& j : sewCandidateThread) {
+                    Surface* sj = _surfaces[j];
+
+                    if(testSew(si, sj, distCf, indicesMatched)) {
+                        auto& si_vertices = si->getVertices();
+                        auto& sj_vertices = sj->getVertices();
+                        for(int j = 0; j < indicesMatched.size(); j++) {
+                            int s2_idx = indicesMatched[j];
+                            if(s2_idx >= 0) {
+                                Vertex* vi = si_vertices[j];
+                                Vertex* vj = sj_vertices[s2_idx];
+                                toMergeThread.insert(vi->objectId() < vj->objectId() ? std::make_pair(vi, vj) : std::make_pair(vj, vi));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    );
+
+    // Reduce
+
+    std::unordered_map<Vertex*, std::unordered_set<Vertex*> > toMerge, fromMerge;
+    for(auto& toMergeThread : toMergePool) 
+        for(auto& p : toMergeThread) {
+            Vertex* vt, *vf;
+            std::tie(vt, vf) = p;
+            toMerge[vt].insert(vf);
+            fromMerge[vf].insert(vt);
+        }
+    std::vector<Vertex*> fromMergeKeys;
+    fromMergeKeys.reserve(fromMerge.size());
+    for(auto& p : fromMerge) 
+        fromMergeKeys.push_back(p.first);
+
+    std::vector<std::vector<std::vector<Vertex*> > > mergeSetsPool(ThreadPool::size());
+    std::vector<size_t> mergeSetsSizePool(ThreadPool::size(), 0);
+    parallel_for(
+        ThreadPool::size(), 
+        [&mergeSetsPool, &mergeSetsSizePool, &toMerge, &fromMerge, &fromMergeKeys](int tid) -> void {
+            std::vector<std::vector<Vertex*> >& mergeSetsThread = mergeSetsPool[tid];
+            size_t& mergeSetsSizeThread = mergeSetsSizePool[tid];
+
+            std::unordered_set<Vertex*> rootElements;
+            for(unsigned int i = tid; i < fromMergeKeys.size(); i += ThreadPool::size()) {
+                Vertex* vi = fromMergeKeys[i];
+                if(toMerge.count(vi) == 0) 
+                    rootElements.insert(vi);
+            }
+
+            for(auto& vi : rootElements) {
+                std::unordered_set<Vertex*> mergeSet;
+                _recursive_set_insert(fromMerge, mergeSet, vi);
+                if(mergeSet.size() > 1) {
+                    mergeSetsThread.emplace_back(mergeSet.begin(), mergeSet.end());
+                    mergeSetsSizeThread++;
+                }
+            }
+        }
+    );
+
+    // Sew
+
+    size_t numMerge = 0;
+    for(auto& mergeSetsSizeThread : mergeSetsSizePool) 
+        numMerge += mergeSetsSizeThread;
+    std::vector<std::vector<Vertex*> > toMergeVec;
+    toMergeVec.reserve(numMerge);
+    for(auto& mergeSetsThread : mergeSetsPool) 
+        for(auto& mergeSet : mergeSetsThread) 
+            toMergeVec.push_back(mergeSet);
+
+    return Vertex::merge(toMergeVec, distCf);
+}
+
+HRESULT Surface::sew(const std::vector<SurfaceHandle>& _surfaces, const FloatP_t &distCf) {
+    std::vector<Surface*> surfaces(_surfaces.size());
+    parallel_for(surfaces.size(), [&surfaces, &_surfaces](int i) -> void { surfaces[i] = _surfaces[i].surface(); });
     return Surface::sew(surfaces, distCf);
 }
 
@@ -1166,7 +1623,7 @@ Surface *Surface::split(Vertex *v1, Vertex *v2) {
 /** Find a contiguous set of surface vertices partioned by a cut plane */
 static std::vector<Vertex*> Surface_SurfaceCutPlaneVertices(Surface *s, const FVector4 &planeEq) {
     // Calculate side of cut plane
-    auto s_vertices = s->getVertices();
+    auto& s_vertices = s->getVertices();
     std::vector<bool> planeEq_newSide;
     planeEq_newSide.reserve(s_vertices.size());
     size_t num_to_new = 0;
@@ -1190,7 +1647,7 @@ static std::vector<Vertex*> Surface_SurfaceCutPlaneVertices(Surface *s, const FV
     std::vector<bool>::iterator b_itr = planeEq_newSide.begin() + 1;
     std::vector<bool>::iterator b_itr_prev = b_itr - 1;
     std::vector<bool>::iterator b_itr_next = b_itr + 1;
-    std::vector<Vertex*>::iterator v_itr = s_vertices.begin() + 1;
+    auto v_itr = s_vertices.begin() + 1;
     while(!v_new_end) { 
         if(!v_new_start) {
             if(*b_itr && !*b_itr_prev) {
@@ -1233,7 +1690,7 @@ static HRESULT Surface_SurfaceCutPlanePointsPairs(
     *v_new_end = verts_new_s.back();
 
     // Determine coordinates of new vertices where cut plane intersects the surface
-    auto s_vertices = s->getVertices();
+    auto& s_vertices = s->getVertices();
     for(int i = 0; i < s_vertices.size(); i++) {
         if(s_vertices[i]->objectId() == (*v_new_start)->objectId()) 
             *v_old_start = i == 0 ? s_vertices.back() : s_vertices[i - 1];
@@ -1518,7 +1975,7 @@ std::vector<BodyHandle> SurfaceHandle::getBodies() const {
 
 std::vector<VertexHandle> SurfaceHandle::getVertices() const {
     SurfaceHandle_GETOBJ(o, {});
-    std::vector<Vertex*> _result = o->getVertices();
+    auto& _result = o->getVertices();
     std::vector<VertexHandle> result;
     result.reserve(_result.size());
     for(auto &_v : _result) 
@@ -1944,6 +2401,52 @@ HRESULT SurfaceType::add(const SurfaceHandle &i) {
     return S_OK;
 }
 
+HRESULT SurfaceType::add(const std::vector<SurfaceHandle>& i) {
+    std::vector<Surface*> _i(i.size());
+    std::vector<int32_t> instanceIds(i.size());
+    std::vector<std::unordered_map<SurfaceType*, std::unordered_set<SurfaceHandle>> > surfaceTypeMapPool(ThreadPool::size());
+    std::vector<HRESULT> resultPool(ThreadPool::size(), S_OK);
+    parallel_for(ThreadPool::size(), [&i, &_i, &instanceIds, &surfaceTypeMapPool, &resultPool](int tid) -> void {
+        std::unordered_map<SurfaceType*, std::unordered_set<SurfaceHandle> >& surfaceTypeMapThread = surfaceTypeMapPool[tid];
+        for(int j = tid; j < _i.size(); j += ThreadPool::size()) {
+            SurfaceHandle ij = i[j];
+            if(!ij) {
+                resultPool[tid] = E_FAIL;
+                return;
+            }
+
+            Surface* _ij = ij.surface();
+            if(!_ij) {
+                resultPool[tid] = E_FAIL;
+                return;
+            }
+
+            _i[j] = _ij;
+            instanceIds[j] = ij.id;
+            SurfaceType* stype = _ij->type();
+            if(stype) 
+                surfaceTypeMapThread[stype].insert(ij);
+        }
+    });
+    for(auto& resultThread : resultPool) 
+        if(resultThread != S_OK) {
+            return tf_error(resultThread, "Failed to add object");
+        }
+
+    for(auto& surfaceTypeMapThread : surfaceTypeMapPool) 
+        for(auto& st : surfaceTypeMapThread) 
+            if(st.first->remove({st.second.begin(), st.second.end()}) != S_OK) 
+                return E_FAIL;
+
+    const int stid = this->id;
+    parallel_for(_i.size(), [&_i, &stid](int i) -> void { _i[i]->typeId = stid; });
+    if(this->_instanceIds.capacity() - this->_instanceIds.size() < instanceIds.size()) 
+        this->_instanceIds.reserve(this->_instanceIds.size() + instanceIds.size());
+    for(auto& sid : instanceIds) this->_instanceIds.push_back(sid);
+
+    return S_OK;
+}
+
 HRESULT SurfaceType::remove(const SurfaceHandle &i) {
     if(!i) 
         return tf_error(E_FAIL, "Invalid object");
@@ -1957,6 +2460,42 @@ HRESULT SurfaceType::remove(const SurfaceHandle &i) {
 
     this->_instanceIds.erase(itr);
     _i->typeId = -1;
+    return S_OK;
+}
+
+HRESULT SurfaceType::remove(const std::vector<SurfaceHandle>& i) {
+    std::vector<Surface*> _i(i.size());
+    std::vector<HRESULT> resultPool(ThreadPool::size(), S_OK);
+    parallel_for(ThreadPool::size(), [&i, &_i, &resultPool](int tid) -> void {
+        for(int j = tid; j < _i.size(); j += ThreadPool::size()) {
+            SurfaceHandle ij = i[j];
+            if(!ij) {
+                resultPool[tid] = E_FAIL;
+                return;
+            }
+
+            Surface* _ij = ij.surface();
+            if(!_ij) {
+                resultPool[tid] = E_FAIL;
+                return;
+            }
+
+            _i[j] = _ij;
+        }
+    });
+    for(auto& resultThread : resultPool) 
+        if(resultThread != S_OK) {
+            return tf_error(resultThread, "Failed to add object");
+        }
+
+    for(auto& s : i) {
+        auto itr = std::find(this->_instanceIds.begin(), this->_instanceIds.end(), s.id);
+        if(itr == this->_instanceIds.end()) 
+            return tf_error(E_FAIL, "Instance not of this type");
+        this->_instanceIds.erase(itr);
+    }
+
+    parallel_for(_i.size(), [&_i](int j) -> void { _i[j]->typeId = -1; });
     return S_OK;
 }
 
@@ -1990,6 +2529,39 @@ static SurfaceHandle SurfaceType_fromVertices(SurfaceType *stype, const std::vec
         return SurfaceHandle();
     }
     _s->setDensity(stype->density);
+    return s;
+}
+
+static std::vector<SurfaceHandle> SurfaceType_fromVertices(SurfaceType *stype, const std::vector<std::vector<VertexHandle> > &vertices) {
+    if(vertices.empty()) 
+        return {};
+
+    std::vector<SurfaceHandle> s = Surface::create(vertices);
+    std::vector<HRESULT> resultPool(ThreadPool::size(), S_OK);
+    const FloatP_t density = stype->density;
+    parallel_for(
+        ThreadPool::size(), 
+        [&s, &resultPool, &density](int tid) -> void {
+            for(int i = tid; i < s.size(); i += ThreadPool::size()) {
+                Surface* _s = s[i].surface();
+                if(!_s) {
+                    resultPool[tid] = E_FAIL;
+                    return;
+                }
+                _s->setDensity(density);
+            }
+        }
+    );
+    for(auto& resultThread : resultPool) 
+        if(resultThread != S_OK) {
+            TF_Log(LOG_ERROR) << "Failed to create instance";
+            return {};
+        }
+
+    if(stype->add(s) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
     return s;
 }
 
@@ -2036,6 +2608,146 @@ SurfaceHandle SurfaceType::operator() (TissueForge::io::ThreeDFFaceData *face) {
             _positions.push_back(vv->position);
     
     return (*this)(_positions);
+}
+
+std::vector<SurfaceHandle> SurfaceType::operator() (const std::vector<std::vector<VertexHandle> >& _vertices) {
+    return SurfaceType_fromVertices(this, _vertices);
+}
+
+std::vector<SurfaceHandle> SurfaceType::operator() (const std::vector<std::vector<FVector3> > &_positions) {
+    if(_positions.empty()) 
+        return {};
+
+    std::vector<unsigned int> positionIndices(_positions.size() + 1);
+    positionIndices[0] = 0;
+    for(unsigned int i = 0; i < _positions.size(); i++) 
+        positionIndices[i+1] = positionIndices[i] + _positions[i].size();
+
+    std::vector<FVector3> positionsFlat(positionIndices.back());
+    parallel_for(
+        _positions.size(), 
+        [&positionsFlat, &_positions, &positionIndices](int i) -> void {
+            std::vector<FVector3> _positions_i = _positions[i];
+            const unsigned int ii = positionIndices[i];
+            for(int j = 0; j < _positions_i.size(); j++) 
+                positionsFlat[ii + j] = _positions_i[j];
+        }
+    );
+
+    std::vector<VertexHandle> verticesFlat = Vertex::create(positionsFlat);
+    if(verticesFlat.empty()) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+
+    std::vector<std::vector<VertexHandle> > vertices(_positions.size());
+    parallel_for(
+        vertices.size(), 
+        [&verticesFlat, &vertices, &positionIndices](int i) -> void {
+            std::vector<VertexHandle>& vertices_i = vertices[i];
+            auto itr = positionIndices.begin() + i;
+            const unsigned int ii = *itr, ij = *(itr + 1);
+            vertices_i.reserve(ij - ii);
+            for(unsigned int j = ii; j < ij; j++) 
+                vertices_i.push_back(verticesFlat[j]);
+        }
+    );
+
+    return (*this)(vertices);
+}
+
+std::vector<SurfaceHandle> SurfaceType::operator() (const std::vector<TissueForge::io::ThreeDFFaceData*>& faces, const bool& safe) {
+    if(faces.empty()) 
+        return {};
+
+    if(safe) {
+
+        // Purge topology and build new vertices for each face
+
+        std::vector<std::vector<FVector3> > positions(faces.size());
+        std::vector<HRESULT> resultPool(ThreadPool::size(), S_OK);
+        parallel_for(
+            ThreadPool::size(), 
+            [&faces, &positions, &resultPool](int tid) -> void {
+                std::vector<TissueForge::io::ThreeDFVertexData*> vverts;
+
+                for(int i = tid; i < faces.size(); i += ThreadPool::size()) {
+                    TissueForge::io::ThreeDFFaceData* face = faces[i];
+                    if(Surface_order3DFFaceVertices(face, vverts) != S_OK) {
+                        resultPool[tid] = E_FAIL;
+                        return;
+                    }
+                    std::vector<FVector3>& positions_i = positions[i];
+                    positions_i.reserve(vverts.size());
+                    for(auto& vv : vverts) 
+                        positions_i.push_back(vv->position);
+                }
+            }
+        );
+
+        return (*this)(positions);
+
+    }
+    else {
+
+        // Use existing topology and hope for the best
+
+        // create vertices
+
+        std::vector<std::unordered_set<TissueForge::io::ThreeDFVertexData*> > verticesFlatPool(ThreadPool::size());
+        parallel_for(
+            ThreadPool::size(), 
+            [&faces, &verticesFlatPool](int tid) -> void {
+                std::unordered_set<TissueForge::io::ThreeDFVertexData*>& verticesFlatThread = verticesFlatPool[tid];
+                for(int i = tid; i < faces.size(); i += ThreadPool::size()) 
+                    for(auto& v : faces[i]->getVertices()) 
+                        verticesFlatThread.insert(v);
+            }
+        );
+        size_t numVertices = 0;
+        for(auto& verticesFlatThread : verticesFlatPool) 
+            numVertices += verticesFlatThread.size();
+        std::unordered_set<TissueForge::io::ThreeDFVertexData*> verticesFlat;
+        verticesFlat.reserve(numVertices);
+        for(auto& verticesFlatThread : verticesFlatPool) 
+            verticesFlat.insert(verticesFlatThread.begin(), verticesFlatThread.end());
+        std::vector<TissueForge::io::ThreeDFVertexData*> verticesFlatVec(verticesFlat.begin(), verticesFlat.end());
+
+        auto newVertices = Vertex::create(verticesFlatVec);
+
+        // construct structured vertices input and forward
+
+        std::unordered_map<int, int> vertexIdMap;
+        vertexIdMap.reserve(newVertices.size());
+        for(unsigned int i = 0; i < newVertices.size(); i++) {
+            int importId = verticesFlatVec[i]->id;
+            int createdId = newVertices[i].id;
+            if(importId < 0) {
+                TF_Log(LOG_ERROR) << "Vertex import failed";
+                return {};
+            }
+            else if(createdId < 0) {
+                TF_Log(LOG_ERROR) << "Vertex construction failed";
+                return {};
+            }
+            vertexIdMap[importId] = createdId;
+        }
+
+        std::vector<std::vector<VertexHandle> > vertexInput(faces.size());
+        parallel_for(
+            faces.size(), 
+            [&faces, &vertexIdMap, &vertexInput](int i) -> void {
+                std::vector<VertexHandle>& vertexInputFace = vertexInput[i];
+                std::vector<TissueForge::io::ThreeDFVertexData*> vverts;
+                Surface_order3DFFaceVertices(faces[i], vverts);
+                for(auto& v : vverts) 
+                    vertexInputFace.emplace_back(vertexIdMap[v->id]);
+            }
+        );
+
+        return (*this)(vertexInput);
+
+    }
 }
 
 SurfaceHandle SurfaceType::nPolygon(const unsigned int &n, const FVector3 &center, const FloatP_t &radius, const FVector3 &ax1, const FVector3 &ax2) {
@@ -2107,8 +2819,8 @@ SurfaceHandle SurfaceType::replace(VertexHandle &toReplace, std::vector<FloatP_t
 
     // Disconnect replaced vertex from all surfaces
     _toReplace = toReplace.vertex();
-    std::vector<Surface*> toReplaceSurfaces = _toReplace->getSurfaces();
-    std::vector<Vertex*> affectedVertices = _toReplace->connectedVertices();
+    auto& toReplaceSurfaces = _toReplace->getSurfaces();
+    auto& affectedVertices = _toReplace->connectedVertices();
     for(auto &s : toReplaceSurfaces) {
         s->remove(_toReplace);
         _toReplace->remove(s);

--- a/source/models/vertex/solver/tfSurface.h
+++ b/source/models/vertex/solver/tfSurface.h
@@ -135,6 +135,20 @@ namespace TissueForge::models::vertex {
          */
         static SurfaceHandle create(TissueForge::io::ThreeDFFaceData *face);
 
+        /**
+         * @brief Construct surfaces from sets of vertices
+         * 
+         * @param _vertices sets of vertices
+         */
+        static std::vector<SurfaceHandle> create(const std::vector<std::vector<VertexHandle> > &_vertices);
+
+        /**
+         * @brief Construct surfaces from faces
+         * 
+         * @param _faces faces
+         */
+        static std::vector<SurfaceHandle> create(const std::vector<TissueForge::io::ThreeDFFaceData*> &_faces);
+
         MESHBOJ_DEFINES_DECL(Body);
         MESHOBJ_DEFINEDBY_DECL(Vertex);
         MESHOBJ_CLASSDEF(MeshObjTypeLabel::SURFACE)
@@ -253,6 +267,15 @@ namespace TissueForge::models::vertex {
         static HRESULT destroy(SurfaceHandle &target);
 
         /**
+         * @brief Destroy surfaces. 
+         * 
+         * Any resulting vertices without a surface are also destroyed. 
+         * 
+         * @param target handles to a surface to destroy
+         */
+        static HRESULT destroy(const std::vector<Surface*>& target);
+
+        /**
          * @brief Refresh internal ordering of defined bodies
          */
         HRESULT refreshBodies();
@@ -277,7 +300,7 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the vertices that define the surface
          */
-        std::vector<Vertex*> getVertices() const { return vertices; }
+        const std::vector<Vertex*>& getVertices() const { return vertices; }
 
         /**
          * @brief Find a vertex that defines this surface
@@ -358,32 +381,32 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the surface unnormalized normal
          */
-        FVector3 getUnnormalizedNormal() const { return normal; }
+        const FVector3& getUnnormalizedNormal() const { return normal; }
 
         /**
          * @brief Get the centroid
          */
-        FVector3 getCentroid() const { return centroid; }
+        const FVector3& getCentroid() const { return centroid; }
 
         /**
          * @brief Get the velocity, calculated as the velocity of the centroid
          */
-        FVector3 getVelocity() const { return velocity; }
+        const FVector3& getVelocity() const { return velocity; }
 
         /**
          * @brief Get the area
          */
-        FloatP_t getArea() const { return area; }
+        const FloatP_t& getArea() const { return area; }
 
         /**
          * @brief Get the perimeter
          */
-        FloatP_t getPerimeter() const { return perimeter; }
+        const FloatP_t& getPerimeter() const { return perimeter; }
 
         /**
          * @brief Get the mass density; only used in 2D simulation
          */
-        FloatP_t getDensity() const { return density; }
+        const FloatP_t& getDensity() const { return density; }
 
         /**
          * @brief Set the mass density; only used in 2D simulation
@@ -473,6 +496,16 @@ namespace TissueForge::models::vertex {
         bool contains(const FVector3 &pos) const;
 
         /**
+         * Test whether two vertices would be sewn.
+         * 
+         * @param s1 first surface
+         * @param s2 second surface
+         * @param distCf distance criterion coefficient
+         * @param indicesMatched indices to the vertices of the second surface matched to those of the first surface
+        */
+        static bool testSew(Surface* s1, Surface* s2, const FloatP_t& distCf, std::vector<int>& indicesMatched);
+
+        /**
          * @brief Sew two surfaces 
          * 
          * All vertices are merged that are a distance apart less than a distance criterion. 
@@ -508,7 +541,7 @@ namespace TissueForge::models::vertex {
          * @param _surfaces a set of surfaces 
          * @param distCf distance criterion coefficient
          */
-        static HRESULT sew(std::vector<Surface*> _surfaces, const FloatP_t &distCf=0.01);
+        static HRESULT sew(const std::vector<Surface*>& _surfaces, const FloatP_t &distCf=0.01);
 
         /**
          * @brief Sew a set of surfaces 
@@ -521,7 +554,7 @@ namespace TissueForge::models::vertex {
          * @param distCf distance criterion coefficient
          * @return HRESULT 
          */
-        static HRESULT sew(std::vector<SurfaceHandle> _surfaces, const FloatP_t &distCf=0.01);
+        static HRESULT sew(const std::vector<SurfaceHandle>& _surfaces, const FloatP_t &distCf=0.01);
 
         /**
          * @brief Merge with a surface. The passed surface is destroyed. 
@@ -1148,11 +1181,25 @@ namespace TissueForge::models::vertex {
         HRESULT add(const SurfaceHandle &i);
 
         /**
+         * @brief Add instances
+         * 
+         * @param i instances to add
+         */
+        HRESULT add(const std::vector<SurfaceHandle>& i);
+
+        /**
          * @brief Remove an instance
          * 
          * @param i instance to remove
          */
         HRESULT remove(const SurfaceHandle &i);
+
+        /**
+         * @brief Remove instances
+         * 
+         * @param i instances to remove
+         */
+        HRESULT remove(const std::vector<SurfaceHandle>& i);
 
         /**
          * @brief list of instances that belong to this type
@@ -1189,6 +1236,28 @@ namespace TissueForge::models::vertex {
          * @param face a face
          */
         SurfaceHandle operator() (TissueForge::io::ThreeDFFaceData *face);
+
+        /**
+         * @brief Construct surfaces of this type from sets of vertices
+         * 
+         * @param _vertices sets of vertices
+         */
+        std::vector<SurfaceHandle> operator() (const std::vector<std::vector<VertexHandle> >& _vertices);
+
+        /**
+         * @brief Construct surfaces of this type from sets of positions
+         * 
+         * @param _positions sets of positions
+         */
+        std::vector<SurfaceHandle> operator() (const std::vector<std::vector<FVector3> > &_positions);
+
+        /**
+         * @brief Construct a surface of this type from faces
+         * 
+         * @param faces faces
+         * @param safe flag to discard existing topology and construct new vertices for each passed face
+         */
+        std::vector<SurfaceHandle> operator() (const std::vector<TissueForge::io::ThreeDFFaceData*>& faces, const bool& safe=true);
 
         /**
          * @brief Construct a polygon with n vertices circumscribed on a circle
@@ -1251,6 +1320,16 @@ inline std::ostream &operator<<(std::ostream& os, const TissueForge::models::ver
 {
     os << o.str().c_str();
     return os;
+}
+
+namespace std {
+
+    template <> 
+    struct hash<TissueForge::models::vertex::SurfaceHandle> {
+        size_t operator() (const TissueForge::models::vertex::SurfaceHandle& h) const {
+            return hash<int>()(h.id);
+        }
+    };
 }
 
 #endif // _MODELS_VERTEX_SOLVER_TFSURFACE_H_

--- a/source/models/vertex/solver/tfVertex.cpp
+++ b/source/models/vertex/solver/tfVertex.cpp
@@ -29,6 +29,7 @@
 #include <tfError.h>
 #include <tfLogger.h>
 #include <tfEngine.h>
+#include <tfTaskScheduler.h>
 #include <io/tfIO.h>
 #include <io/tfFIO.h>
 
@@ -52,6 +53,13 @@ using namespace TissueForge::models::vertex;
     Vertex *name;                                                       \
     if(this->id < 0 || !(name = Mesh::get()->getVertex(this->id))) {    \
         VertexHandle_INVALIDHANDLERR; return retval; }
+
+
+struct PairHash_VertexPtr_VertexPtr {
+    size_t operator() (const std::pair<Vertex*, Vertex*>& p) const {
+        return std::hash<Vertex*>()(p.first) ^ std::hash<Vertex*>()(p.second);
+    }
+};
 
 
 ////////////
@@ -199,6 +207,17 @@ static Vertex *Vertex_create(const unsigned int &_pid) {
     return result;
 }
 
+static std::vector<Vertex*> Vertex_create(const std::vector<unsigned int>& _pids) {
+    Vertex_GETMESH(mesh, {});
+    std::vector<Vertex*> result(_pids.size(), 0);
+    Vertex** data = result.data();
+    if(mesh->create(&data, _pids) != S_OK) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+    return result;
+}
+
 static Vertex *Vertex_create(const FVector3 &position, int &pid) {
     MeshParticleType *ptype = MeshParticleType_get();
     Mesh *mesh = Mesh::get();
@@ -222,8 +241,43 @@ static Vertex *Vertex_create(const FVector3 &position, int &pid) {
     return Vertex_create(ph->id);
 }
 
+static std::vector<Vertex*> Vertex_create(const std::vector<FVector3>& positions, std::vector<unsigned int>& pids) {
+    if(positions.empty()) 
+        return {};
+
+    MeshParticleType *ptype = MeshParticleType_get();
+    Mesh *mesh = Mesh::get();
+    if(!ptype) {
+        TF_Log(LOG_ERROR) << "Could not instantiate particle type";
+        return {};
+    } 
+    else if(!mesh) {
+        TF_Log(LOG_ERROR) << "Could not get mesh";
+        return {};
+    }
+
+    auto _positions = positions;
+    auto _pids = ptype->factory(0, &_positions);
+    if(_pids.empty()) {
+        TF_Log(LOG_ERROR) << "Could not instantiate particles";
+        return {};
+    }
+    pids = std::vector<unsigned int>(_pids.size());
+    parallel_for(_pids.size(), [&pids, &_pids](int i) -> void { pids[i] = _pids[i]; });
+
+    return Vertex_create(pids);
+}
+
 static Vertex *Vertex_create(TissueForge::io::ThreeDFVertexData *vdata, int &pid) {
     return Vertex_create(vdata->position, pid);
+}
+
+static std::vector<Vertex*> Vertex_create(const std::vector<TissueForge::io::ThreeDFVertexData*>& vdata, std::vector<unsigned int>& pids) {
+    std::vector<FVector3> positions(vdata.size());
+
+    parallel_for(vdata.size(), [&vdata, &positions](int i) -> void { positions[i] = vdata[i]->position; });
+
+    return Vertex_create(positions, pids);
 }
 
 VertexHandle Vertex::create(const unsigned int &_pid) {
@@ -265,6 +319,80 @@ VertexHandle Vertex::create(TissueForge::io::ThreeDFVertexData *vdata) {
         result->positionChanged();
     }
     return VertexHandle(result->_objId);
+}
+
+std::vector<VertexHandle> Vertex::create(const std::vector<unsigned int>& _pids) {
+    std::vector<Vertex*> vertices = Vertex_create(_pids);
+    if(vertices.empty() && !_pids.empty()) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+
+    std::vector<VertexHandle> result(_pids.size());
+
+    parallel_for(
+        _pids.size(), 
+        [&result, &_pids, &vertices](int i) -> void {
+            unsigned int _pid = _pids[i];
+            Vertex *v = vertices[i];
+            v->pid = _pid;
+            if(_pid >= 0) {
+                v->positionChanged();
+            }
+            result[i] = VertexHandle(v->_objId);
+        }
+    );
+    return result;
+}
+
+std::vector<VertexHandle> Vertex::create(const std::vector<FVector3>& positions) {
+    if(positions.empty()) 
+        return {};
+
+    std::vector<unsigned int> pids;
+    std::vector<Vertex*> vertices = Vertex_create(positions, pids);
+    if(vertices.empty()) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+
+    std::vector<VertexHandle> result(vertices.size());
+    parallel_for(
+        vertices.size(), 
+        [&vertices, &pids, &result](int i) -> void {
+            Vertex* v = vertices[i];
+            v->pid = pids[i];
+            if(v->pid >= 0) 
+                v->positionChanged();
+            result[i] = VertexHandle(v->_objId);
+        }
+    );
+    return result;
+}
+
+std::vector<VertexHandle> Vertex::create(const std::vector<TissueForge::io::ThreeDFVertexData*>& vdata) {
+    if(vdata.empty()) 
+        return {};
+
+    std::vector<unsigned int> pids;
+    std::vector<Vertex*> vertices = Vertex_create(vdata, pids);
+    if(vertices.empty()) {
+        TF_Log(LOG_ERROR);
+        return {};
+    }
+
+    std::vector<VertexHandle> result(vertices.size());
+    parallel_for(
+        vertices.size(), 
+        [&vertices, &pids, &result](int i) -> void {
+            Vertex* v = vertices[i];
+            v->pid = pids[i];
+            if(v->pid >= 0) 
+                v->positionChanged();
+            result[i] = VertexHandle(v->_objId);
+        }
+    );
+    return result;
 }
 
 bool Vertex::defines(const Surface *obj) const { MESHBOJ_DEFINES_DEF(getVertices) }
@@ -365,6 +493,72 @@ HRESULT Vertex::destroy() {
     return S_OK;
 }
 
+HRESULT Vertex::destroy(const std::vector<Vertex*>& toDestroy) {
+
+    std::vector<std::unordered_set<int> > particleIdsToDestroyPool(ThreadPool::size());
+    std::vector<std::unordered_set<Vertex*> > verticesToDestroyPool(ThreadPool::size());
+    std::vector<std::unordered_set<Surface*> > surfacesToDestroyPool(ThreadPool::size());
+    parallel_for(
+        ThreadPool::size(), 
+        [&particleIdsToDestroyPool, &verticesToDestroyPool, &surfacesToDestroyPool, &toDestroy](int tid) -> void {
+            std::unordered_set<int>& particleIdsToDestroyThread = particleIdsToDestroyPool[tid];
+            std::unordered_set<Vertex*>& verticesToDestroyThread = verticesToDestroyPool[tid];
+            std::unordered_set<Surface*>& surfacesToDestroyThread = surfacesToDestroyPool[tid];
+            for(int i = tid; i < toDestroy.size(); i += ThreadPool::size()) {
+                Vertex* v = toDestroy[i];
+                if(!v || v->objectId() < 0) 
+                    continue;
+                particleIdsToDestroyThread.insert(v->getPartId());
+                verticesToDestroyThread.insert(v);
+                for(auto& s : v->getSurfaces()) 
+                    surfacesToDestroyThread.insert(s);
+            }
+        }
+    );
+
+    size_t numSurfaces = 0;
+    for(auto& surfacesToDestroyThread : surfacesToDestroyPool) 
+        numSurfaces += surfacesToDestroyThread.size();
+    if(numSurfaces > 0) {
+        std::unordered_set<Surface*> surfacesToDestroy;
+        surfacesToDestroy.reserve(numSurfaces);
+        for(auto& surfacesToDestroyThread : surfacesToDestroyPool) 
+            surfacesToDestroy.insert(surfacesToDestroyThread.begin(), surfacesToDestroyThread.end());
+        Surface::destroy(std::vector<Surface*>{surfacesToDestroy.begin(), surfacesToDestroy.end()});
+    }
+
+    size_t numVertices = 0;
+    for(auto& verticesToDestroyThread : verticesToDestroyPool) 
+        numVertices += verticesToDestroyThread.size();
+    std::vector<Vertex*> verticesToDestroyVec;
+    if(numVertices > 0) {
+        std::unordered_set<Vertex*> verticesToDestroy;
+        verticesToDestroy.reserve(numVertices);
+        for(auto& verticesToDestroyThread : verticesToDestroyPool) 
+            verticesToDestroy.insert(verticesToDestroyThread.begin(), verticesToDestroyThread.end());
+        verticesToDestroyVec = std::vector<Vertex*>(verticesToDestroy.begin(), verticesToDestroy.end());
+        Mesh::get()->remove(verticesToDestroyVec.data(), verticesToDestroyVec.size());
+
+        std::unordered_set<int> particleIdsToDestroy;
+        particleIdsToDestroy.reserve(numVertices);
+        for(auto& particleIdsToDestroyThread : particleIdsToDestroyPool) 
+            particleIdsToDestroy.insert(particleIdsToDestroyThread.begin(), particleIdsToDestroyThread.end());
+        for(auto& pid : particleIdsToDestroy) 
+            ParticleHandle(pid).destroy();
+    }
+
+    parallel_for(
+        verticesToDestroyVec.size(), 
+        [&verticesToDestroyVec](int i) -> void {
+            Vertex* v = verticesToDestroyVec[i];
+            v->pid = -1;
+            v->_connectedVertices.clear();
+        }
+    );
+
+    return S_OK;
+}
+
 std::vector<Body*> Vertex::getBodies() const {
     std::unordered_set<Body*> result;
     for(auto &s : surfaces) 
@@ -413,78 +607,212 @@ Body *Vertex::findBody(const FVector3 &dir) const {
     return result;
 }
 
-HRESULT Vertex::transferBondsTo(Vertex *other) {
-    ParticleHandle *ph = this->particle();
+static HRESULT Vertex_destroyOrTransferBonds(
+    Vertex* source, 
+    Vertex* target, 
+    std::vector<std::pair<uint32_t, int> >& bondsInfo, 
+    std::vector<std::pair<uint32_t, int> >& anglesInfo, 
+    std::vector<std::pair<uint32_t, int> >& dihedralsInfo
+) {
+    ParticleHandle *ph = source->particle();
+    const int source_pid = source->getPartId();
+    const int target_pid = target->getPartId();
 
-    for(auto &ah : ph->getAngles()) {
-        Angle *a = ah.get();
-        if(a->i == this->pid) {
-            if(a->j == other->pid || a->k == other->pid) 
-                ah.destroy();
-            else 
-                a->i = other->pid;
-        } 
-        else if(a->j == this->pid) {
-            if(a->i == other->pid || a->k == other->pid) 
-                ah.destroy();
-            else 
-                a->j = other->pid;
-        } 
-        else if(a->k == this->pid) {
-            if(a->i == other->pid || a->j == other->pid) 
-                ah.destroy();
-            else 
-                a->k = other->pid;
-        }
-    }
-    
     std::unordered_set<uint32_t> bonded_ids;
-    bonded_ids.insert(other->pid);
+    bonded_ids.insert(target_pid);
     for(auto &bh : ph->getBonds()) {
         Bond *b = bh.get();
-        if(b->i == this->pid) {
-            if(std::find(bonded_ids.begin(), bonded_ids.end(), b->j) != bonded_ids.end()) 
-                bh.destroy();
-            else {
-                b->i = other->pid;
-                bonded_ids.insert(b->j);
-            }
+        int result = -1;
+        if(b->i == source_pid && std::find(bonded_ids.begin(), bonded_ids.end(), b->j) == bonded_ids.end()) {
+            result = 0;
+            bonded_ids.insert(b->j);
         } 
-        else if(b->j == this->pid) {
-            if(std::find(bonded_ids.begin(), bonded_ids.end(), b->i) != bonded_ids.end()) 
-                bh.destroy();
-            else {
-                b->j = other->pid;
-                bonded_ids.insert(b->i);
-            }
-        } 
+        else if(b->j == source_pid && std::find(bonded_ids.begin(), bonded_ids.end(), b->i) == bonded_ids.end()) {
+            result = 1;
+            bonded_ids.insert(b->i);
+        }
+        bondsInfo.push_back({b->id, result});
+    }
+    
+    for(auto &ah : ph->getAngles()) {
+        Angle *a = ah.get();
+        int result = -1;
+        if(a->i == source_pid && a->j != target_pid && a->k != target_pid) 
+            result = 0;
+        else if(a->j == source_pid && a->i != target_pid && a->k != target_pid) 
+            result = 1;
+        else if(a->k == source_pid && a->i != target_pid && a->j != target_pid) 
+            result = 2;
+        anglesInfo.push_back({a->id, result});
     }
     
     for(auto &dh : ph->getDihedrals()) {
         Dihedral *d = dh.get();
-        if(d->i == this->pid) {
-            if(d->j == other->pid || d->k == other->pid || d->l == other->pid) 
-                dh.destroy();
-            else 
-                d->i = other->pid;
-        } 
-        else if(d->j == this->pid) {
-            if(d->i == other->pid || d->k == other->pid || d->l == other->pid) 
-                dh.destroy();
-            else 
-                d->j = other->pid;
-        } 
-        else if(d->k == this->pid) {
-            if(d->i == other->pid || d->j == other->pid || d->l == other->pid) 
-                dh.destroy();
-            else 
-                d->k = other->pid;
+        int result = -1;
+        if(d->i == source_pid && d->j != target_pid && d->k != target_pid && d->l != target_pid) 
+            result = 0;
+        else if(d->j == source_pid && d->i != target_pid && d->k != target_pid && d->l != target_pid) 
+            result = 1;
+        else if(d->k == source_pid && d->i != target_pid && d->j != target_pid && d->l != target_pid) 
+            result = 2;
+        else if(d->l == source_pid && d->i != target_pid && d->j != target_pid && d->k != target_pid) 
+            result = 3;
+        dihedralsInfo.push_back({d->id, result});
+    }
+
+    return S_OK;
+}
+
+HRESULT Vertex::transferBondsTo(Vertex *other) {
+    std::vector<std::pair<uint32_t, int> > bondsInfo;
+    std::vector<std::pair<uint32_t, int> > anglesInfo;
+    std::vector<std::pair<uint32_t, int> > dihedralsInfo;
+    if(Vertex_destroyOrTransferBonds(this, other, bondsInfo, anglesInfo, dihedralsInfo) != S_OK) 
+        return E_FAIL;
+    for(auto& p : bondsInfo) {
+        uint32_t bid;
+        int result;
+        std::tie(bid, result) = p;
+        BondHandle bh(bid);
+        if(result < 0) bh.destroy();
+        else if(result == 0) bh.get()->i = other->pid;
+        else if(result == 1) bh.get()->j = other->pid;
+    }
+    for(auto& p : anglesInfo) {
+        uint32_t bid;
+        int result;
+        std::tie(bid, result) = p;
+        AngleHandle bh(bid);
+        if(result < 0) bh.destroy();
+        else if(result == 0) bh.get()->i = other->pid;
+        else if(result == 1) bh.get()->j = other->pid;
+        else if(result == 2) bh.get()->k = other->pid;
+    }
+    for(auto& p : dihedralsInfo) {
+        uint32_t bid;
+        int result;
+        std::tie(bid, result) = p;
+        DihedralHandle bh(bid);
+        if(result < 0) bh.destroy();
+        else if(result == 0) bh.get()->i = other->pid;
+        else if(result == 1) bh.get()->j = other->pid;
+        else if(result == 2) bh.get()->k = other->pid;
+        else if(result == 3) bh.get()->l = other->pid;
+    }
+
+    return S_OK;
+}
+
+HRESULT Vertex::transferBondsTo(const std::vector<std::pair<Vertex*, Vertex*> >& targets) {
+    std::vector<std::unordered_map<uint32_t, std::unordered_map<int, int> > > bondsInfoPool(ThreadPool::size());
+    std::vector<std::unordered_map<uint32_t, std::unordered_map<int, int> > > anglesInfoPool(ThreadPool::size());
+    std::vector<std::unordered_map<uint32_t, std::unordered_map<int, int> > > dihedralsInfoPool(ThreadPool::size());
+
+    parallel_for(
+        ThreadPool::size(), 
+        [&targets, &anglesInfoPool, &bondsInfoPool, &dihedralsInfoPool](int tid) -> void {
+            std::unordered_map<uint32_t, std::unordered_map<int, int> >& bondsInfoThread = bondsInfoPool[tid];
+            std::unordered_map<uint32_t, std::unordered_map<int, int> >& anglesInfoThread = anglesInfoPool[tid];
+            std::unordered_map<uint32_t, std::unordered_map<int, int> >& dihedralsInfoThread = dihedralsInfoPool[tid];
+            for(int i = tid; i < targets.size(); i += ThreadPool::size()) {
+                Vertex* vs, *vt;
+                std::tie(vs, vt) = targets[i];
+                const int vtid = vt->getPartId();
+                std::vector<std::pair<uint32_t, int> > _bondsInfo;
+                std::vector<std::pair<uint32_t, int> > _anglesInfo;
+                std::vector<std::pair<uint32_t, int> > _dihedralsInfo;
+                Vertex_destroyOrTransferBonds(vs, vt, _bondsInfo, _anglesInfo, _dihedralsInfo);
+                for(auto& p : _bondsInfo) {
+                    uint32_t bid;
+                    int result;
+                    std::tie(bid, result) = p;
+                    bondsInfoThread[bid][vtid] = result;
+                }
+                for(auto& p : _anglesInfo) {
+                    uint32_t bid;
+                    int result;
+                    std::tie(bid, result) = p;
+                    anglesInfoThread[bid][vtid] = result;
+                }
+                for(auto& p : _dihedralsInfo) {
+                    uint32_t bid;
+                    int result;
+                    std::tie(bid, result) = p;
+                    dihedralsInfoThread[bid][vtid] = result;
+                }
+            }
         }
-        else if(d->l == this->pid) {
-            if(d->i == other->pid || d->j == other->pid || d->k == other->pid) 
-                dh.destroy();
-            else 
-                d->l = other->pid;
+    );
+
+    std::unordered_map<uint32_t, std::unordered_map<int, int> > bondsInfo;
+    std::unordered_map<uint32_t, std::unordered_map<int, int> > anglesInfo;
+    std::unordered_map<uint32_t, std::unordered_map<int, int> > dihedralsInfo;
+
+    for(auto& bondsInfoThread : bondsInfoPool) 
+        for(auto& m : bondsInfoThread) {
+            auto& mf = bondsInfo[m.first];
+            for(auto& p : m.second) 
+                mf[p.first] = p.second;
+        }
+    for(auto& anglesInfoThread : anglesInfoPool) 
+        for(auto& m : anglesInfoThread) {
+            auto& mf = anglesInfo[m.first];
+            for(auto& p : m.second) 
+                mf[p.first] = p.second;
+        }
+    for(auto& dihedralsInfoThread : dihedralsInfoPool) 
+        for(auto& m : dihedralsInfoThread) {
+            auto& mf = dihedralsInfo[m.first];
+            for(auto& p : m.second) 
+                mf[p.first] = p.second;
+        }
+
+    for(auto& m : bondsInfo) {
+        const int bid = m.first;
+        for(auto& p : m.second) {
+            const int vtid = p.first;
+            const int result = p.second;
+
+            BondHandle bh(bid);
+            if(result < 0) {
+                bh.destroy();
+                break;
+            }
+            else if(result == 0) bh.get()->i = vtid;
+            else if(result == 1) bh.get()->j = vtid;
+        }
+    }
+    for(auto& m : anglesInfo) {
+        const int bid = m.first;
+        for(auto& p : m.second) {
+            const int vtid = p.first;
+            const int result = p.second;
+
+            AngleHandle bh(bid);
+            if(result < 0) {
+                bh.destroy();
+                break;
+            }
+            else if(result == 0) bh.get()->i = vtid;
+            else if(result == 1) bh.get()->j = vtid;
+            else if(result == 2) bh.get()->k = vtid;
+        }
+    }
+    for(auto& m : dihedralsInfo) {
+        const int bid = m.first;
+        for(auto& p : m.second) {
+            const int vtid = p.first;
+            const int result = p.second;
+
+            DihedralHandle bh(bid);
+            if(result < 0) {
+                bh.destroy();
+                break;
+            }
+            else if(result == 0) bh.get()->i = vtid;
+            else if(result == 1) bh.get()->j = vtid;
+            else if(result == 2) bh.get()->k = vtid;
+            else if(result == 3) bh.get()->l = vtid;
         }
     }
 
@@ -747,6 +1075,246 @@ VertexHandle Vertex::replace(const FVector3 &position, BodyHandle &toReplace) {
     return VertexHandle(v->objectId());
 }
 
+static HRESULT Vertex_merge_assm(
+    Vertex* toKeep, 
+    Vertex* toRemove, 
+    std::unordered_set<Surface*>& common_s, 
+    std::unordered_set<Surface*>& different_s
+) {
+    // In common surfaces, just remove; in different surfaces, replace
+    auto& toRemove_surfaces = toRemove->getSurfaces();
+    common_s.reserve(toRemove_surfaces.size());
+    different_s.reserve(toRemove_surfaces.size());
+    for(auto &s : toRemove_surfaces) {
+        if(!toKeep->defines(s)) 
+            different_s.insert(s);
+        else {
+            // Prevent invalid surface
+            if(s->getVertices().size() < 4) 
+                return E_FAIL;
+            common_s.insert(s);
+        }
+    }
+
+    return S_OK;
+}
+
+static HRESULT Vertex_merge(Vertex* toKeep, Vertex* toRemove, const FloatP_t& lenCf) {
+
+    // In common surfaces, just remove; in different surfaces, replace
+    std::unordered_set<Surface*> common_s, different_s;
+    auto& toRemove_surfaces = toRemove->getSurfaces();
+    std::vector<Vertex*> toRemoveConnectedVertices = toRemove->connectedVertices();
+    if(Vertex_merge_assm(toKeep, toRemove, common_s, different_s) != S_OK) {
+        TF_Log(LOG_DEBUG) << "Insufficient surface vertices. Ignoring";
+        return E_FAIL;
+    }
+    for(auto &s : common_s) {
+        s->remove(toRemove);
+        toRemove->remove(s);
+    }
+    for(auto &s : different_s) {
+        toRemove->remove(s);
+        toKeep->add(s);
+        s->replace(toKeep, toRemove);
+    }
+
+    toKeep->updateConnectedVertices();
+    std::unordered_set<Vertex*> affectedVertices;
+    for(auto &v : toKeep->connectedVertices()) 
+        affectedVertices.insert(v);
+    for(auto &v : toRemoveConnectedVertices) 
+        affectedVertices.insert(v);
+    for(auto &v : affectedVertices) 
+        v->updateConnectedVertices();
+    
+    // Set new position
+    const FVector3 posToKeep = toKeep->getPosition();
+    const FVector3 newPos = posToKeep + (toRemove->getPosition() - posToKeep) * lenCf;
+    if(toKeep->setPosition(newPos) != S_OK) 
+        return E_FAIL;
+
+    MeshSolver::log(MeshLogEventType::Create, {toKeep->objectId(), toRemove->objectId()}, {toKeep->objType(), toRemove->objType()}, "merge");
+    
+    if(toRemove->transferBondsTo(toKeep) != S_OK || toRemove->destroy() != S_OK) 
+        return E_FAIL;
+
+    if(!Mesh::get()->qualityWorking() && MeshSolver::positionChanged() != S_OK)
+        return E_FAIL;
+
+    return S_OK;
+}
+
+static HRESULT Vertex_merge(const std::vector<std::pair<Vertex*, Vertex*> >& toMerge, const FloatP_t& lenCf) {
+
+    std::vector<std::unordered_set<Vertex*> > verticesAffectedPool(ThreadPool::size());
+    std::vector<std::unordered_map<Vertex*, std::unordered_set<Surface*> > > toRemoveSurfacesByVertexPool(ThreadPool::size()), toKeepSurfacesByVertexPool(ThreadPool::size());
+    std::vector<std::unordered_map<Surface*, std::unordered_set<Vertex*> > > toRemoveVerticesBySurfacePool(ThreadPool::size());
+    std::vector<std::unordered_map<Surface*, std::unordered_set<std::pair<Vertex*, Vertex*>, PairHash_VertexPtr_VertexPtr> > > toReplaceVerticesBySurfacePool(ThreadPool::size());
+
+    parallel_for(
+        ThreadPool::size(), 
+        [&toMerge, &verticesAffectedPool, &toRemoveSurfacesByVertexPool, &toKeepSurfacesByVertexPool, &toRemoveVerticesBySurfacePool, &toReplaceVerticesBySurfacePool](int tid) -> void {
+            std::unordered_set<Vertex*>& verticesAffectedThread = verticesAffectedPool[tid];
+            std::unordered_map<Vertex*, std::unordered_set<Surface*> >& toRemoveSurfacesByVertexThread = toRemoveSurfacesByVertexPool[tid];
+            std::unordered_map<Vertex*, std::unordered_set<Surface*> >& toKeepSurfacesByVertexThread = toKeepSurfacesByVertexPool[tid];
+            std::unordered_map<Surface*, std::unordered_set<Vertex*> >& toRemoveVerticesBySurfaceThread = toRemoveVerticesBySurfacePool[tid];
+            std::unordered_map<Surface*, std::unordered_set<std::pair<Vertex*, Vertex*>, PairHash_VertexPtr_VertexPtr> >& toReplaceVerticesBySurfaceThread = toReplaceVerticesBySurfacePool[tid];
+            for(int i = tid; i < toMerge.size(); i += ThreadPool::size()) {
+                Vertex* toKeep, *toRemove;
+                std::tie(toKeep, toRemove) = toMerge[i];
+
+                std::unordered_set<Surface*> common_s, different_s;
+                if(Vertex_merge_assm(toKeep, toRemove, common_s, different_s) == S_OK) {
+                    for(auto &s : common_s) {
+                        toRemoveSurfacesByVertexThread[toRemove].insert(s);
+                        toRemoveVerticesBySurfaceThread[s].insert(toRemove);
+                    }
+                    for(auto &s : different_s) {
+                        toRemoveSurfacesByVertexThread[toRemove].insert(s);
+                        toKeepSurfacesByVertexThread[toKeep].insert(s);
+                        toReplaceVerticesBySurfaceThread[s].insert({toKeep, toRemove});
+                    }
+                }
+                for(auto& v : toRemove->connectedVertices()) 
+                    verticesAffectedThread.insert(v);
+            }
+        }
+    );
+
+    std::unordered_map<Vertex*, std::unordered_set<Surface*> > toRemoveSurfacesByVertex;
+    for(auto& toRemoveSurfacesByVertexThread : toRemoveSurfacesByVertexPool) 
+        for(auto& p : toRemoveSurfacesByVertexThread) 
+            toRemoveSurfacesByVertex[p.first].insert(p.second.begin(), p.second.end());
+    std::vector<Vertex*> toRemoveSurfacesByVertexKeys;
+    toRemoveSurfacesByVertexKeys.reserve(toRemoveSurfacesByVertex.size());
+    for(auto& p : toRemoveSurfacesByVertex) 
+        toRemoveSurfacesByVertexKeys.push_back(p.first);
+    parallel_for(
+        toRemoveSurfacesByVertexKeys.size(), 
+        [&toRemoveSurfacesByVertex, &toRemoveSurfacesByVertexKeys](int i) -> void {
+            Vertex* v = toRemoveSurfacesByVertexKeys[i];
+            for(auto& s : toRemoveSurfacesByVertex[v]) 
+                v->remove(s);
+        }
+    );
+
+    std::unordered_map<Vertex*, std::unordered_set<Surface*> > toKeepSurfacesByVertex;
+    for(auto& toKeepSurfacesByVertexThread : toKeepSurfacesByVertexPool) 
+        for(auto& p : toKeepSurfacesByVertexThread) 
+            toKeepSurfacesByVertex[p.first].insert(p.second.begin(), p.second.end());
+    std::vector<Vertex*> toKeepSurfacesByVertexKeys;
+    toKeepSurfacesByVertexKeys.reserve(toKeepSurfacesByVertex.size());
+    for(auto& p : toKeepSurfacesByVertex) 
+        toKeepSurfacesByVertexKeys.push_back(p.first);
+    parallel_for(
+        toKeepSurfacesByVertexKeys.size(), 
+        [&toKeepSurfacesByVertex, &toKeepSurfacesByVertexKeys](int i) -> void {
+            Vertex* v = toKeepSurfacesByVertexKeys[i];
+            for(auto& s : toKeepSurfacesByVertex[v]) 
+                v->add(s);
+        }
+    );
+
+    std::unordered_map<Surface*, std::unordered_set<Vertex*> > toRemoveVerticesBySurface;
+    for(auto& toRemoveVerticesBySurfaceThread : toRemoveVerticesBySurfacePool) 
+        for(auto& p : toRemoveVerticesBySurfaceThread) 
+            toRemoveVerticesBySurface[p.first].insert(p.second.begin(), p.second.end());
+    std::vector<Surface*> toRemoveVerticesBySurfaceKeys;
+    toRemoveVerticesBySurfaceKeys.reserve(toRemoveVerticesBySurface.size());
+    for(auto& p : toRemoveVerticesBySurface) 
+        toRemoveVerticesBySurfaceKeys.push_back(p.first);
+    parallel_for(
+        toRemoveVerticesBySurfaceKeys.size(), 
+        [&toRemoveVerticesBySurface, &toRemoveVerticesBySurfaceKeys](int i) -> void {
+            Surface* s = toRemoveVerticesBySurfaceKeys[i];
+            for(auto& v : toRemoveVerticesBySurface[s]) 
+                s->remove(v);
+        }
+    );
+
+    std::unordered_map<Surface*, std::unordered_set<std::pair<Vertex*, Vertex*>, PairHash_VertexPtr_VertexPtr> > toReplaceVerticesBySurface;
+    for(auto& toReplaceVerticesBySurfaceThread : toReplaceVerticesBySurfacePool) 
+        for(auto& p : toReplaceVerticesBySurfaceThread) 
+            toReplaceVerticesBySurface[p.first].insert(p.second.begin(), p.second.end());
+    std::vector<Surface*> toReplaceVerticesBySurfaceKeys;
+    toReplaceVerticesBySurfaceKeys.reserve(toReplaceVerticesBySurface.size());
+    for(auto& p : toReplaceVerticesBySurface) 
+        toReplaceVerticesBySurfaceKeys.push_back(p.first);
+    parallel_for(
+        toReplaceVerticesBySurfaceKeys.size(), 
+        [&toReplaceVerticesBySurface, &toReplaceVerticesBySurfaceKeys](int i) -> void {
+            Surface* s = toReplaceVerticesBySurfaceKeys[i];
+            for(auto& p : toReplaceVerticesBySurface[s]) 
+                s->replace(p.first, p.second);
+        }
+    );
+
+    parallel_for(
+        ThreadPool::size(), 
+        [&toMerge, &verticesAffectedPool](int tid) -> void {
+            std::unordered_set<Vertex*>& verticesAffectedThread = verticesAffectedPool[tid];
+            for(int i = tid; i < toMerge.size(); i += ThreadPool::size()) {
+                Vertex* toKeep, *toRemove;
+                std::tie(toKeep, toRemove) = toMerge[i];
+                toKeep->updateConnectedVertices();
+                for(auto& v : toKeep->connectedVertices()) 
+                    verticesAffectedThread.insert(v);
+            }
+        }
+    );
+
+    size_t numVerticesAffected = 0;
+    for(auto& verticesAffectedThread : verticesAffectedPool) 
+        numVerticesAffected += verticesAffectedThread.size();
+    std::unordered_set<Vertex*> verticesAffected;
+    verticesAffected.reserve(numVerticesAffected);
+    for(auto& verticesAffectedThread : verticesAffectedPool) 
+        verticesAffected.insert(verticesAffectedThread.begin(), verticesAffectedThread.end());
+    std::vector<Vertex*> verticesAffectedVec(verticesAffected.begin(), verticesAffected.end());
+
+    parallel_for(verticesAffectedVec.size(), [&verticesAffectedVec](int i) -> void { verticesAffectedVec[i]->updateConnectedVertices(); });
+    
+    // Set new position
+
+    std::vector<Vertex*> toRemoveVec(toMerge.size());
+    parallel_for(
+        toMerge.size(), 
+        [&toMerge, &toRemoveVec, &lenCf](int i) -> void {
+            Vertex* toKeep, *toRemove;
+            std::tie(toKeep, toRemove) = toMerge[i];
+
+            toRemoveVec[i] = toRemove;
+
+            const FVector3 posToKeep = toKeep->getPosition();
+            const FVector3 newPos = posToKeep + (toRemove->getPosition() - posToKeep) * lenCf;
+            toKeep->setPosition(newPos);
+        }
+    );
+
+    // log
+
+    if(MeshLogger::getForwardLogging()) 
+        for(auto& p : toMerge) {
+            Vertex* toKeep, *toRemove;
+            std::tie(toKeep, toRemove) = p;
+            MeshSolver::log(MeshLogEventType::Create, {toKeep->objectId(), toRemove->objectId()}, {toKeep->objType(), toRemove->objType()}, "merge");
+        }
+    
+    // transfer bonds
+    if(Vertex::transferBondsTo(toMerge) != S_OK) 
+        return E_FAIL;
+
+    // destroy vertices
+    if(Vertex::destroy(toRemoveVec) != S_OK) 
+        return E_FAIL;
+
+    if(!Mesh::get()->qualityWorking() && MeshSolver::positionChanged() != S_OK)
+        return E_FAIL;
+
+    return S_OK;
+}
+
 HRESULT Vertex::merge(Vertex *toRemove, const FloatP_t &lenCf) {
 
     // In common surfaces, just remove; in different surfaces, replace
@@ -798,6 +1366,44 @@ HRESULT Vertex::merge(Vertex *toRemove, const FloatP_t &lenCf) {
 
     if(!Mesh::get()->qualityWorking() && MeshSolver::positionChanged() != S_OK)
         return E_FAIL;
+
+    return S_OK;
+}
+
+HRESULT Vertex::merge(const std::vector<std::vector<Vertex*> >& toMerge, const FloatP_t& lenCf) {
+
+    // iterate through "levels" of merged vertices and use Vertex_merge
+    //  E.g., at level "2", loop through all elements of toMerge and construct a vector of pairs targeting the second merged vertex; do this until there are no more iterations
+    int level = 0;
+    int levelMax = 0;
+    for(auto& toMerge_v : toMerge) 
+        levelMax = std::max(levelMax, (int)toMerge_v.size() - 1);
+
+    std::vector<std::vector<std::pair<Vertex*, Vertex*> > > toMergeLevelPool;
+    auto func = [&toMerge, &level, &toMergeLevelPool](int tid) -> void {
+        std::vector<std::pair<Vertex*, Vertex*> >& toMergeLevelThread = toMergeLevelPool[tid];
+        for(int i = tid; i < toMerge.size(); i += ThreadPool::size()) {
+            const std::vector<Vertex*>& toMerge_i = toMerge[i];
+            if(toMerge_i.size() <= level + 1) 
+                continue;
+            auto itrKeep = toMerge_i.begin();
+            toMergeLevelThread.emplace_back(*itrKeep, *(itrKeep + level + 1));
+        }
+    };
+
+    for(; level < levelMax; level++) {
+        toMergeLevelPool = std::vector<std::vector<std::pair<Vertex*, Vertex*> > >(ThreadPool::size());
+        parallel_for(ThreadPool::size(), func);
+        size_t numTargets = 0;
+        for(auto& toMergeLevelThread : toMergeLevelPool) 
+            numTargets += toMergeLevelThread.size();
+        std::vector<std::pair<Vertex*, Vertex*> > toMergeLevel;
+        toMergeLevel.reserve(numTargets);
+        for(auto& toMergeLevelThread : toMergeLevelPool) 
+            for(auto& p : toMergeLevelThread) 
+                toMergeLevel.push_back(p);
+        Vertex_merge(toMergeLevel, lenCf);
+    }
 
     return S_OK;
 }
@@ -1209,7 +1815,7 @@ std::vector<BodyHandle> VertexHandle::getBodies() const {
 
 std::vector<SurfaceHandle> VertexHandle::getSurfaces() const {
     VertexHandle_GETOBJ(o, {});
-    auto surfaces = o->getSurfaces();
+    auto& surfaces = o->getSurfaces();
     std::vector<SurfaceHandle> result;
     result.reserve(surfaces.size());
     for(auto &s : surfaces) 
@@ -1476,7 +2082,7 @@ namespace TissueForge::io {
             TF_IOTOEASY(fileElement, metaData, "pid", ph->getId());
         }
 
-        std::vector<TissueForge::models::vertex::Surface*> surfaces = dataElement->getSurfaces();
+        auto& surfaces = dataElement->getSurfaces();
         std::vector<int> surfaceIds;
         surfaceIds.reserve(surfaces.size());
         for(auto &s : surfaces) 

--- a/source/models/vertex/solver/tfVertex.h
+++ b/source/models/vertex/solver/tfVertex.h
@@ -117,6 +117,27 @@ namespace TissueForge::models::vertex {
          */
         static VertexHandle create(TissueForge::io::ThreeDFVertexData *vdata);
 
+        /**
+         * @brief Create vertices
+         * 
+         * @param _pids ids of underlying particles
+         */
+        static std::vector<VertexHandle> create(const std::vector<unsigned int>& _pids);
+
+        /**
+         * @brief Create vertices
+         * 
+         * @param positions positions of vertices
+         */
+        static std::vector<VertexHandle> create(const std::vector<FVector3>& positions);
+
+        /**
+         * @brief Create vertices
+         * 
+         * @param vdata vertices
+         */
+        static std::vector<VertexHandle> create(const std::vector<TissueForge::io::ThreeDFVertexData*>& vdata);
+
         MESHBOJ_DEFINES_DECL(Surface);
         MESHBOJ_DEFINES_DECL(Body);
         MESHOBJ_CLASSDEF(MeshObjTypeLabel::VERTEX)
@@ -177,6 +198,13 @@ namespace TissueForge::models::vertex {
          */
         HRESULT replace(Surface *toInsert, Surface *toRemove);
 
+        /**
+         * @brief Destroy instances
+         * 
+         * @param toDestroy instances to destroy
+        */
+        static HRESULT destroy(const std::vector<Vertex*>& toDestroy);
+
         /** 
          * @brief Get the id of the underlying particle 
          */
@@ -190,7 +218,7 @@ namespace TissueForge::models::vertex {
         /** 
          * @brief Get the surfaces defined by the vertex 
          */
-        std::vector<Surface*> getSurfaces() const { return surfaces; }
+        const std::vector<Surface*>& getSurfaces() const { return surfaces; }
 
         /**
          * @brief Find a surface defined by this vertex
@@ -216,7 +244,7 @@ namespace TissueForge::models::vertex {
          * 
          * A vertex is connected if it defines an edge with this vertex.
          */
-        std::vector<Vertex*> connectedVertices() const { return _connectedVertices; }
+        const std::vector<Vertex*>& connectedVertices() const { return _connectedVertices; }
 
         /**
          * @brief Get the surfaces that this vertex and another vertex both define
@@ -253,7 +281,7 @@ namespace TissueForge::models::vertex {
         /** 
          * @brief Get the current position 
          */
-        FVector3 getPosition() const { return _particlePosition; }
+        const FVector3& getPosition() const { return _particlePosition; }
 
         /**
          * @brief Set the current position
@@ -266,12 +294,12 @@ namespace TissueForge::models::vertex {
         /**
          * @brief Get the current velocity
          */
-        FVector3 getVelocity() const { return _particleVelocity; }
+        const FVector3& getVelocity() const { return _particleVelocity; }
 
         /**
          * @brief Get the cached particle mass from the most recent update
          */
-        FloatP_t getCachedParticleMass() const { return _particleMass; }
+        const FloatP_t& getCachedParticleMass() const { return _particleMass; }
 
         /**
          * @brief Transfer all bonds to another vertex
@@ -279,6 +307,13 @@ namespace TissueForge::models::vertex {
          * @param other another vertex
          */
         HRESULT transferBondsTo(Vertex *other);
+
+        /**
+         * @brief Transfer all bonds to other vertices
+         * 
+         * @param targets target vertices; first element is source, second element is target
+         */
+        static HRESULT transferBondsTo(const std::vector<std::pair<Vertex*, Vertex*> >& targets);
 
         /**
          * @brief Replace a surface
@@ -339,6 +374,16 @@ namespace TissueForge::models::vertex {
          * @param lenCf distance coefficient in [0, 1] for where to place the vertex, from the kept vertex to the removed vertex
          */
         HRESULT merge(Vertex *toRemove, const FloatP_t &lenCf=0.5f);
+
+        /**
+         * @brief Merge sets of vertices. 
+         * 
+         * The first instance of each list absorbs the remaining vertices. 
+         * 
+         * @param toMerge sets of vertices to merge
+         * @param lenCf distance coefficient in [0, 1] for where to place the vertex, from the kept vertex to the removed vertex
+        */
+        static HRESULT merge(const std::vector<std::vector<Vertex*> >& toMerge, const FloatP_t &lenCf=0.5f);
 
         /**
          * @brief Inserts a vertex between two vertices
@@ -750,6 +795,16 @@ inline std::ostream &operator<<(std::ostream& os, const TissueForge::models::ver
 {
     os << o.str().c_str();
     return os;
+}
+
+namespace std {
+
+    template <> 
+    struct hash<TissueForge::models::vertex::VertexHandle> {
+        size_t operator() (const TissueForge::models::vertex::VertexHandle& h) const {
+            return hash<int>()(h.id);
+        }
+    };
 }
 
 #endif // _MODELS_VERTEX_SOLVER_TFVERTEX_H_

--- a/wraps/C/models/vertex/solver/tfCBody.cpp
+++ b/wraps/C/models/vertex/solver/tfCBody.cpp
@@ -107,7 +107,7 @@ HRESULT tfVertexSolverBodyHandle_fromString(struct tfVertexSolverBodyHandleHandl
 }
 
 HRESULT tfVertexSolverBodyHandle_destroy(struct tfVertexSolverBodyHandleHandle *handle) {
-    return TissueForge::capi::destroyHandle<BodyHandle, tfVertexSolverBodyHandleHandle>(handle);
+    return TissueForge::capi::destroyHandle<BodyHandle, tfVertexSolverBodyHandleHandle>(handle) ? S_OK : E_FAIL;
 }
 
 HRESULT tfVertexSolverBodyHandle_getId(struct tfVertexSolverBodyHandleHandle *handle, int *objId) {
@@ -155,6 +155,14 @@ HRESULT tfVertexSolverBodyHandle_objType(struct tfVertexSolverBodyHandleHandle *
 HRESULT tfVertexSolverBodyHandle_destroyBody(struct tfVertexSolverBodyHandleHandle *handle) {
     TFC_BODYHANDLE_GET(handle);
     return bhandle->destroy();
+}
+
+HRESULT tfVertexSolverBodyHandle_destroyBodies(struct tfVertexSolverBodyHandleHandle **handles, unsigned int numObjs) {
+    TFC_PTRCHECK(handles);
+    std::vector<Body*> bodies(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        bodies[i] = TissueForge::castC<BodyHandle, tfVertexSolverBodyHandleHandle>(handles[i])->body();
+    return Body::destroy(bodies);
 }
 
 HRESULT tfVertexSolverBodyHandle_destroyBodyC(struct tfVertexSolverBodyHandleHandle *handle) {

--- a/wraps/C/models/vertex/solver/tfCBody.h
+++ b/wraps/C/models/vertex/solver/tfCBody.h
@@ -157,6 +157,14 @@ CAPI_FUNC(HRESULT) tfVertexSolverBodyHandle_objType(struct tfVertexSolverBodyHan
 CAPI_FUNC(HRESULT) tfVertexSolverBodyHandle_destroyBody(struct tfVertexSolverBodyHandleHandle *handle);
 
 /**
+ * @brief Destroy instances
+ * 
+ * @param handles populated handles
+ * @param numObjs number of objects to destroy
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverBodyHandle_destroyBodies(struct tfVertexSolverBodyHandleHandle **handles, unsigned int numObjs);
+
+/**
  * @brief Destroy the body. 
  * 
  * Any resulting surfaces without a body are also destroyed. 

--- a/wraps/C/models/vertex/solver/tfCMesh.cpp
+++ b/wraps/C/models/vertex/solver/tfCMesh.cpp
@@ -137,6 +137,25 @@ HRESULT tfVertexSolverMeshCreateVertex(struct tfVertexSolverVertexHandleHandle *
     return tfVertexSolverVertexHandle_init(handle, v->objectId());
 }
 
+HRESULT tfVertexSolverMeshCreateVertices(struct tfVertexSolverVertexHandleHandle **handles, unsigned int *pids, unsigned int numObjs) {
+    TFC_MESH_GET(mesh);
+    TFC_PTRCHECK(handles);
+    TFC_PTRCHECK(pids);
+    if(numObjs == 0) 
+        return S_OK;
+    std::vector<unsigned int> _pids(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _pids[i] = pids[i];
+    std::vector<Vertex*> vs(numObjs, NULL);
+    Vertex** vs_data = vs.data();
+    if(mesh->create(&vs_data, _pids) != S_OK) 
+        return E_FAIL;
+    for(unsigned int i = 0; i < numObjs; i++) 
+        if(tfVertexSolverVertexHandle_init(handles[i], vs[i]->objectId()) != S_OK) 
+            return E_FAIL;
+    return S_OK;
+}
+
 HRESULT tfVertexSolverMeshCreateSurface(struct tfVertexSolverSurfaceHandleHandle *handle) {
     TFC_MESH_GET(mesh);
     TFC_PTRCHECK(handle);
@@ -146,6 +165,21 @@ HRESULT tfVertexSolverMeshCreateSurface(struct tfVertexSolverSurfaceHandleHandle
     return tfVertexSolverSurfaceHandle_init(handle, s->objectId());
 }
 
+HRESULT tfVertexSolverMeshCreateSurfaces(struct tfVertexSolverSurfaceHandleHandle **handles, unsigned int numObjs) {
+    TFC_MESH_GET(mesh);
+    TFC_PTRCHECK(handles);
+    if(numObjs == 0) 
+        return S_OK;
+    std::vector<Surface*> ss(numObjs, NULL);
+    Surface** ss_data = ss.data();
+    if(mesh->create(&ss_data, numObjs) != S_OK) 
+        return E_FAIL;
+    for(unsigned int i = 0; i < numObjs; i++) 
+        if(tfVertexSolverSurfaceHandle_init(handles[i], ss[i]->objectId()) != S_OK) 
+            return E_FAIL;
+    return S_OK;
+}
+
 HRESULT tfVertexSolverMeshCreateBody(struct tfVertexSolverBodyHandleHandle *handle) {
     TFC_MESH_GET(mesh);
     TFC_PTRCHECK(handle);
@@ -153,6 +187,21 @@ HRESULT tfVertexSolverMeshCreateBody(struct tfVertexSolverBodyHandleHandle *hand
     if(mesh->create(&b) != S_OK) 
         return E_FAIL;
     return tfVertexSolverBodyHandle_init(handle, b->objectId());
+}
+
+HRESULT tfVertexSolverMeshCreateBodies(struct tfVertexSolverBodyHandleHandle **handles, unsigned int numObjs) {
+    TFC_MESH_GET(mesh);
+    TFC_PTRCHECK(handles);
+    if(numObjs == 0) 
+        return S_OK;
+    std::vector<Body*> bs(numObjs, NULL);
+    Body** bs_data = bs.data();
+    if(mesh->create(&bs_data, numObjs) != S_OK) 
+        return E_FAIL;
+    for(unsigned int i = 0; i < numObjs; i++) 
+        if(tfVertexSolverBodyHandle_init(handles[i], bs[i]->objectId()) != S_OK) 
+            return E_FAIL;
+    return S_OK;
 }
 
 HRESULT tfVertexSolverMeshLock() {
@@ -322,6 +371,18 @@ HRESULT tfVertexSolverMeshRemoveVertex(struct tfVertexSolverVertexHandleHandle *
     return mesh->remove(_vObj);
 }
 
+HRESULT tfVertexSolverMeshRemoveVertices(struct tfVertexSolverVertexHandleHandle **v, unsigned int numObjs) {
+    TFC_MESH_GET(mesh);
+    TFC_PTRCHECK(v);
+    if(numObjs == 0) 
+        return S_OK;
+    std::vector<Vertex*> _v(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _v[i] = TissueForge::castC<VertexHandle, tfVertexSolverVertexHandleHandle>(v[i])->vertex();
+    Vertex** o_data = _v.data();
+    return mesh->remove(o_data, numObjs);
+}
+
 HRESULT tfVertexSolverMeshRemoveSurface(struct tfVertexSolverSurfaceHandleHandle *s) {
     TFC_MESH_GET(mesh);
     TFC_PTRCHECK(s);
@@ -331,6 +392,18 @@ HRESULT tfVertexSolverMeshRemoveSurface(struct tfVertexSolverSurfaceHandleHandle
     return mesh->remove(_sObj);
 }
 
+HRESULT tfVertexSolverMeshRemoveSurfaces(struct tfVertexSolverSurfaceHandleHandle **s, unsigned int numObjs) {
+    TFC_MESH_GET(mesh);
+    TFC_PTRCHECK(s);
+    if(numObjs == 0) 
+        return S_OK;
+    std::vector<Surface*> _s(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _s[i] = TissueForge::castC<SurfaceHandle, tfVertexSolverSurfaceHandleHandle>(s[i])->surface();
+    Surface** o_data = _s.data();
+    return mesh->remove(o_data, numObjs);
+}
+
 HRESULT tfVertexSolverMeshRemoveBody(struct tfVertexSolverBodyHandleHandle *b) {
     TFC_MESH_GET(mesh);
     TFC_PTRCHECK(b);
@@ -338,6 +411,18 @@ HRESULT tfVertexSolverMeshRemoveBody(struct tfVertexSolverBodyHandleHandle *b) {
     Body *_bObj = _b->body();
     TFC_PTRCHECK(_bObj);
     return mesh->remove(_bObj);
+}
+
+HRESULT tfVertexSolverMeshRemoveBodies(struct tfVertexSolverBodyHandleHandle **b, unsigned int numObjs) {
+    TFC_MESH_GET(mesh);
+    TFC_PTRCHECK(b);
+    if(numObjs == 0) 
+        return S_OK;
+    std::vector<Body*> _b(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _b[i] = TissueForge::castC<BodyHandle, tfVertexSolverBodyHandleHandle>(b[i])->body();
+    Body** o_data = _b.data();
+    return mesh->remove(o_data, numObjs);
 }
 
 HRESULT tfVertexSolverMeshIs3D(bool *result) {

--- a/wraps/C/models/vertex/solver/tfCMesh.h
+++ b/wraps/C/models/vertex/solver/tfCMesh.h
@@ -93,6 +93,15 @@ CAPI_FUNC(HRESULT) tfVertexSolverMeshEnsureAvailableBodies(unsigned int numAlloc
 CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateVertex(struct tfVertexSolverVertexHandleHandle *handle, unsigned int pid);
 
 /**
+ * @brief Create a vertices
+ * 
+ * @param handles handles to populate
+ * @param pids ids of underlying particles
+ * @param numObjs number of instances to create
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateVertices(struct tfVertexSolverVertexHandleHandle **handles, unsigned int *pids, unsigned int numObjs);
+
+/**
  * @brief Create a surface
  * 
  * @param handle handle to populate
@@ -100,11 +109,27 @@ CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateVertex(struct tfVertexSolverVertexHan
 CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateSurface(struct tfVertexSolverSurfaceHandleHandle *handle);
 
 /**
+ * @brief Create surfaces
+ * 
+ * @param handles handles to populate
+ * @param numObjs number of instances to create
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateSurfaces(struct tfVertexSolverSurfaceHandleHandle **handles, unsigned int numObjs);
+
+/**
  * @brief Create a body
  * 
  * @param handle handle to populate
  */
 CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateBody(struct tfVertexSolverBodyHandleHandle *handle);
+
+/**
+ * @brief Create a bodies
+ * 
+ * @param handles handles to populate
+ * @param numObjs number of instances to create
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverMeshCreateBodies(struct tfVertexSolverBodyHandleHandle *handles, unsigned int numObjs);
 
 /**
  * @brief Locks the mesh for thread-safe operations
@@ -262,6 +287,14 @@ CAPI_FUNC(HRESULT) tfVertexSolverMeshConnectedBodies(
 CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveVertex(struct tfVertexSolverVertexHandleHandle *v);
 
 /**
+ * @brief Remove vertices from the mesh; all connected surfaces and bodies are also removed
+ * 
+ * @param v vertices to remove
+ * @param numObjs number of instances
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveVertices(struct tfVertexSolverVertexHandleHandle **v, unsigned int numObjs);
+
+/**
  * @brief Remove a surface from the mesh; all connected bodies are also removed
  * 
  * @param s surface to remove
@@ -269,11 +302,27 @@ CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveVertex(struct tfVertexSolverVertexHan
 CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveSurface(struct tfVertexSolverSurfaceHandleHandle *s);
 
 /**
+ * @brief Remove surfaces from the mesh; all connected bodies are also removed
+ * 
+ * @param s surfaces to remove
+ * @param numObjs number of instances
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveSurfaces(struct tfVertexSolverSurfaceHandleHandle **s, unsigned int numObjs);
+
+/**
  * @brief Remove a body from the mesh
  * 
  * @param b body to remove
  */
 CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveBody(struct tfVertexSolverBodyHandleHandle *b);
+
+/**
+ * @brief Remove bodies from the mesh
+ * 
+ * @param b bodies to remove
+ * @param numObjs number of instances
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverMeshRemoveBodies(struct tfVertexSolverBodyHandleHandle **b, unsigned int numObjs);
 
 /**
  * @brief Test whether the mesh is 3D. 

--- a/wraps/C/models/vertex/solver/tfCSurface.cpp
+++ b/wraps/C/models/vertex/solver/tfCSurface.cpp
@@ -130,7 +130,7 @@ HRESULT tfVertexSolverSurfaceHandle_fromString(struct tfVertexSolverSurfaceHandl
 }
 
 HRESULT tfVertexSolverSurfaceHandle_destroy(struct tfVertexSolverSurfaceHandleHandle *handle) {
-    return TissueForge::capi::destroyHandle<SurfaceHandle, tfVertexSolverSurfaceHandleHandle>(handle);
+    return TissueForge::capi::destroyHandle<SurfaceHandle, tfVertexSolverSurfaceHandleHandle>(handle) ? S_OK : E_FAIL;
 }
 
 HRESULT tfVertexSolverSurfaceHandle_getId(struct tfVertexSolverSurfaceHandleHandle *handle, int *objId) {
@@ -176,6 +176,14 @@ HRESULT tfVertexSolverSurfaceHandle_objType(struct tfVertexSolverSurfaceHandleHa
 HRESULT tfVertexSolverSurfaceHandle_destroySurface(struct tfVertexSolverSurfaceHandleHandle *handle) {
     TFC_SURFACEHANDLE_GET(handle);
     return shandle->destroy();
+}
+
+HRESULT tfVertexSolverSurfaceHandle_destroySurfaces(struct tfVertexSolverSurfaceHandleHandle **handles, unsigned int numObjs) {
+    TFC_PTRCHECK(handles);
+    std::vector<Surface*> surfaces(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        surfaces[i] = TissueForge::castC<SurfaceHandle, tfVertexSolverSurfaceHandleHandle>(handles[i])->surface();
+    return Surface::destroy(surfaces);
 }
 
 HRESULT tfVertexSolverSurfaceHandle_destroySurfaceC(struct tfVertexSolverSurfaceHandleHandle *handle) {
@@ -1100,6 +1108,72 @@ HRESULT tfVertexSolverSurfaceType_createSurfaceIO(
     TFC_PTRCHECK(_face);
     SurfaceHandle _newObj = (*stype)(_face);
     return tfVertexSolverSurfaceHandle_init(newObj, _newObj.id);
+}
+
+HRESULT tfVertexSolverSurfaceType_createSurfaceVA(
+    struct tfVertexSolverSurfaceTypeHandle *handle, 
+    struct tfVertexSolverVertexHandleHandle ***vertices, 
+    unsigned int numSurfaces, 
+    unsigned int *numVerts, 
+    struct tfVertexSolverSurfaceHandleHandle **newObjs
+) {
+    TFC_SURFACETYPE_GET(handle);
+    TFC_PTRCHECK(vertices);
+    TFC_PTRCHECK(numVerts);
+    TFC_PTRCHECK(newObjs);
+
+    std::vector<std::vector<VertexHandle> > _vertices(numSurfaces);
+    for(unsigned int i = 0; i < numSurfaces; i++) 
+        for(unsigned int j = 0; j < numVerts[i]; j++) 
+            _vertices[i].emplace_back(TissueForge::castC<VertexHandle, tfVertexSolverVertexHandleHandle>(vertices[i][j])->id);
+
+    std::vector<SurfaceHandle> _newObjs = (*stype)(_vertices);
+    for(unsigned int i = 0; i < numSurfaces; i++) 
+        tfVertexSolverSurfaceHandle_init(newObjs[i], _newObjs[i].id);
+    return S_OK;
+}
+
+HRESULT tfVertexSolverSurfaceType_createSurfacePA(
+    struct tfVertexSolverSurfaceTypeHandle *handle, 
+    tfFloatP_t ***spositions, 
+    unsigned int numSurfaces, 
+    unsigned int *numPositions, 
+    struct tfVertexSolverSurfaceHandleHandle **newObjs
+) {
+    TFC_SURFACETYPE_GET(handle);
+    TFC_PTRCHECK(spositions);
+    TFC_PTRCHECK(numPositions);
+    TFC_PTRCHECK(newObjs);
+
+    std::vector<std::vector<FVector3> > _spositions(numSurfaces);
+    for(unsigned int i = 0; i < numSurfaces; i++) 
+        for(unsigned int j = 0; j < numPositions[i]; j++) 
+            _spositions[i].push_back(FVector3::from(spositions[i][j]));
+
+    std::vector<SurfaceHandle> _newObjs = (*stype)(_spositions);
+    for(unsigned int i = 0; i < numSurfaces; i++) 
+        tfVertexSolverSurfaceHandle_init(newObjs[i], _newObjs[i].id);
+    return S_OK;
+}
+
+HRESULT tfVertexSolverSurfaceType_createSurfaceIOA(
+    struct tfVertexSolverSurfaceTypeHandle *handle, 
+    struct tfIoThreeDFFaceDataHandle **faces, 
+    unsigned int numSurfaces, 
+    struct tfVertexSolverSurfaceHandleHandle **newObjs
+) {
+    TFC_SURFACETYPE_GET(handle);
+    TFC_PTRCHECK(faces);
+    TFC_PTRCHECK(newObjs);
+
+    std::vector<io::ThreeDFFaceData*> _faces(numSurfaces);
+    for(unsigned int i = 0; i < numSurfaces; i++) 
+        _faces[i] = TissueForge::castC<io::ThreeDFFaceData, tfIoThreeDFFaceDataHandle>(faces[i]);
+
+    std::vector<SurfaceHandle> _newObjs = (*stype)(_faces);
+    for(unsigned int i = 0; i < numSurfaces; i++) 
+        tfVertexSolverSurfaceHandle_init(newObjs[i], _newObjs[i].id);
+    return S_OK;
 }
 
 HRESULT tfVertexSolverSurfaceType_nPolygon(

--- a/wraps/C/models/vertex/solver/tfCSurface.h
+++ b/wraps/C/models/vertex/solver/tfCSurface.h
@@ -180,6 +180,14 @@ CAPI_FUNC(HRESULT) tfVertexSolverSurfaceHandle_objType(struct tfVertexSolverSurf
 CAPI_FUNC(HRESULT) tfVertexSolverSurfaceHandle_destroySurface(struct tfVertexSolverSurfaceHandleHandle *handle);
 
 /**
+ * @brief Destroy surfaces
+ * 
+ * @param handles populated handles
+ * @param numObjs number of objects to destroy
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverSurfaceHandle_destroySurfaces(struct tfVertexSolverSurfaceHandleHandle **handles, unsigned int numObjs);
+
+/**
  * @brief Destroy an instance. 
  * 
  * Any resulting vertices without a surface are also destroyed. 
@@ -1019,6 +1027,55 @@ CAPI_FUNC(HRESULT) tfVertexSolverSurfaceType_createSurfaceIO(
     struct tfVertexSolverSurfaceTypeHandle *handle, 
     struct tfIoThreeDFFaceDataHandle *face, 
     struct tfVertexSolverSurfaceHandleHandle *newObj
+);
+
+/**
+ * @brief Construct a surface of this type from a set of vertices
+ * 
+ * @param handle populated handle
+ * @param vertices sets of vertices
+ * @param numSurfaces number of surfaces
+ * @param numVerts number of vertices per surface
+ * @param newObjs newly created objects
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverSurfaceType_createSurfaceVA(
+    struct tfVertexSolverSurfaceTypeHandle *handle, 
+    struct tfVertexSolverVertexHandleHandle ***vertices, 
+    unsigned int numSurfaces, 
+    unsigned int *numVerts, 
+    struct tfVertexSolverSurfaceHandleHandle **newObjs
+);
+
+/**
+ * @brief Construct a surface of this type from a set of positions
+ * 
+ * @param handle populated handle
+ * @param positions sets of positions
+ * @param numSurfaces number of surfaces
+ * @param numPositions number of positions
+ * @param newObjs newly created objects
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverSurfaceType_createSurfacePA(
+    struct tfVertexSolverSurfaceTypeHandle *handle, 
+    tfFloatP_t ***spositions, 
+    unsigned int numSurfaces, 
+    unsigned int *numPositions, 
+    struct tfVertexSolverSurfaceHandleHandle **newObjs
+);
+
+/**
+ * @brief Construct a surface of this type from a face
+ * 
+ * @param handle populated handle
+ * @param faces face data
+ * @param numSurfaces number of surfaces
+ * @param newObjs newly created objects
+ */
+CAPI_FUNC(HRESULT) tfVertexSolverSurfaceType_createSurfaceIOA(
+    struct tfVertexSolverSurfaceTypeHandle *handle, 
+    struct tfIoThreeDFFaceDataHandle **faces, 
+    unsigned int numSurfaces, 
+    struct tfVertexSolverSurfaceHandleHandle **newObjs
 );
 
 /**

--- a/wraps/C/models/vertex/solver/tfCVertex.cpp
+++ b/wraps/C/models/vertex/solver/tfCVertex.cpp
@@ -117,6 +117,14 @@ HRESULT tfVertexSolverVertexHandle_destroyVertex(struct tfVertexSolverVertexHand
     return vhandle->destroy();
 }
 
+HRESULT tfVertexSolverVertexHandle_destroyVertices(struct tfVertexSolverVertexHandleHandle **handles, unsigned int numObjs) {
+    TFC_PTRCHECK(handles);
+    std::vector<Vertex*> vertices(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        vertices[i] = TissueForge::castC<VertexHandle, tfVertexSolverVertexHandleHandle>(handles[i])->vertex();
+    return Vertex::destroy(vertices);
+}
+
 HRESULT tfVertexSolverVertexHandle_validate(struct tfVertexSolverVertexHandleHandle *handle, bool *result) {
     TFC_VERTEXHANDLE_GET(handle);
     TFC_PTRCHECK(result);
@@ -427,6 +435,21 @@ HRESULT tfVertexSolverVertexHandle_merge(
     return S_OK;
 }
 
+HRESULT tfVertexSolverVertexHandle_mergeA(
+    struct tfVertexSolverVertexHandleHandle ***handles, 
+    unsigned int numMerges, 
+    unsigned int *numVertices, 
+    tfFloatP_t lenCf
+) {
+    TFC_PTRCHECK(handles);
+    TFC_PTRCHECK(numVertices);
+    std::vector<std::vector<Vertex*> > vertices(numMerges);
+    for(unsigned int i = 0; i < numMerges; i++) 
+        for(unsigned int j = 0; j < numVertices[i]; j++) 
+            vertices[i].push_back(TissueForge::castC<VertexHandle, tfVertexSolverVertexHandleHandle>(handles[i][j])->vertex());
+    return Vertex::merge(vertices, lenCf);
+}
+
 HRESULT tfVertexSolverVertexHandle_insertBetween(
     struct tfVertexSolverVertexHandleHandle *handle, 
     struct tfVertexSolverVertexHandleHandle *v1, 
@@ -517,5 +540,53 @@ HRESULT tfVertexSolverCreateVertexByIOData(struct tfIoThreeDFVertexDataHandle *v
     if(vh.id < 0) 
         return E_FAIL;
     *objId = vh.id;
+    return S_OK;
+}
+
+HRESULT tfVertexSolverCreateVertexByPartIdA(unsigned int *pids, unsigned int numObjs, int **objIds) {
+    TFC_PTRCHECK(pids);
+    TFC_PTRCHECK(objIds);
+    if(numObjs == 0) 
+        return S_OK;
+
+    std::vector<unsigned int> _pids(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _pids[i] = pids[i];
+
+    std::vector<VertexHandle> _newObjs = Vertex::create(_pids);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        (*objIds)[i] = _newObjs[i].id;
+    return S_OK;
+}
+
+HRESULT tfVertexSolverCreateVertexByPositionA(tfFloatP_t **positions, unsigned int numObjs, int **objIds) {
+    TFC_PTRCHECK(positions);
+    TFC_PTRCHECK(objIds);
+    if(numObjs == 0) 
+        return S_OK;
+
+    std::vector<FVector3> _positions(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _positions[i] = FVector3::from(positions[i]);
+
+    std::vector<VertexHandle> _newObjs = Vertex::create(_positions);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        (*objIds)[i] = _newObjs[i].id;
+    return S_OK;
+}
+
+HRESULT tfVertexSolverCreateVertexByIODataA(struct tfIoThreeDFVertexDataHandle **vdata, unsigned int numObjs, int **objIds) {
+    TFC_PTRCHECK(vdata);
+    TFC_PTRCHECK(objIds);
+    if(numObjs == 0) 
+        return S_OK;
+
+    std::vector<io::ThreeDFVertexData*> _vdata(numObjs);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        _vdata[i] = TissueForge::castC<io::ThreeDFVertexData, tfIoThreeDFVertexDataHandle>(vdata[i]);
+
+    std::vector<VertexHandle> _newObjs = Vertex::create(_vdata);
+    for(unsigned int i = 0; i < numObjs; i++) 
+        (*objIds)[i] = _newObjs[i].id;
     return S_OK;
 }

--- a/wraps/C/models/vertex/solver/tfCVertex.h
+++ b/wraps/C/models/vertex/solver/tfCVertex.h
@@ -120,6 +120,14 @@ CAPI_DATA(HRESULT) tfVertexSolverVertexHandle_objType(struct tfVertexSolverVerte
 CAPI_DATA(HRESULT) tfVertexSolverVertexHandle_destroyVertex(struct tfVertexSolverVertexHandleHandle *handle);
 
 /**
+ * @brief Destroy vertices
+ * 
+ * @param handles populated handles
+ * @param numObjs number of objects to destroy
+ */
+CAPI_DATA(HRESULT) tfVertexSolverVertexHandle_destroyVertices(struct tfVertexSolverVertexHandleHandle **handles, unsigned int numObjs);
+
+/**
  * @brief Validate the vertex
  * 
  * @param handle populated handle
@@ -432,6 +440,23 @@ CAPI_DATA(HRESULT) tfVertexSolverVertexHandle_merge(
 );
 
 /**
+ * @brief Merge sets of vertices. 
+ * 
+ * The first instance of each list absorbs the remaining vertices. 
+ * 
+ * @param handle populated handles
+ * @param numMerges number of sets to merge
+ * @param numVertices number of vertices per set
+ * @param lenCf distance coefficient in [0, 1] for where to place the vertex, from the kept vertex to the removed vertex
+ */
+CAPI_DATA(HRESULT) tfVertexSolverVertexHandle_mergeA(
+    struct tfVertexSolverVertexHandleHandle ***handles, 
+    unsigned int numMerges, 
+    unsigned int *numVertices, 
+    tfFloatP_t lenCf
+);
+
+/**
  * @brief Inserts a vertex between two vertices
  * 
  * @param handle populated handle
@@ -513,5 +538,32 @@ CAPI_DATA(HRESULT) tfVertexSolverCreateVertexByPosition(tfFloatP_t *position, in
  * @param objId id of new vertex
  */
 CAPI_DATA(HRESULT) tfVertexSolverCreateVertexByIOData(struct tfIoThreeDFVertexDataHandle *vdata, int *objId);
+
+/**
+ * @brief Create vertices using the id of an existing particles
+ * 
+ * @param pids particle ids
+ * @param numObjs number of vertices to create
+ * @param objIds ids of new vertex
+ */
+CAPI_DATA(HRESULT) tfVertexSolverCreateVertexByPartIdA(unsigned int *pids, unsigned int numObjs, int **objIds);
+
+/**
+ * @brief Create vertices at positions
+ * 
+ * @param positions positions to create new vertices
+ * @param numObjs number of vertices to create
+ * @param objIds ids of new vertices
+ */
+CAPI_DATA(HRESULT) tfVertexSolverCreateVertexByPositionA(tfFloatP_t **positions, unsigned int numObjs, int **objIds);
+
+/**
+ * @brief Create vertices using I/O data
+ * 
+ * @param vdata I/O data
+ * @param numObjs number of vertices to create
+ * @param objIds ids of new vertex
+ */
+CAPI_DATA(HRESULT) tfVertexSolverCreateVertexByIODataA(struct tfIoThreeDFVertexDataHandle **vdata, unsigned int numObjs, int **objIds);
 
 #endif // _WRAPS_C_VERTEX_SOLVER_TFCVERTEX_H_

--- a/wraps/python/models/vertex/solver/examples/capillary_loop.py
+++ b/wraps/python/models/vertex/solver/examples/capillary_loop.py
@@ -43,9 +43,7 @@ mesh_import.translateTo(tf.Universe.center)
 mesh_import.rotate(tf.FMatrix4.rotationX(np.pi / 2).rotation())
 
 # Create the mesh surfaces and sew them
-for io_surf in mesh_import.faces:
-    ctype(face_data=io_surf)
-tfv.Surface.sew(surfs=ctype.instances)
+ctype(face_data=mesh_import.faces, safe_face_data=False)
 
 # Run it!
 tf.show()

--- a/wraps/python/models/vertex/solver/tfSurface.i
+++ b/wraps/python/models/vertex/solver/tfSurface.i
@@ -51,9 +51,9 @@ vertex_solver_MeshObj_prep_py(TissueForge::models::vertex::Surface)
 %rename(_destroy_o) TissueForge::models::vertex::Surface::destroy(Surface*);
 %rename(_destroy_h) TissueForge::models::vertex::Surface::destroy(SurfaceHandle&);
 %rename(_sew_o1) TissueForge::models::vertex::Surface::sew(Surface*, Surface*, const FloatP_t&);
-%rename(_sew_o2) TissueForge::models::vertex::Surface::sew(std::vector<Surface*>, const FloatP_t&);
+%rename(_sew_o2) TissueForge::models::vertex::Surface::sew(const std::vector<Surface*>&, const FloatP_t&);
 %rename(_sew_h1) TissueForge::models::vertex::Surface::sew(const SurfaceHandle&, const SurfaceHandle&, const FloatP_t&);
-%rename(_sew_h2) TissueForge::models::vertex::Surface::sew(std::vector<SurfaceHandle>, const FloatP_t&);
+%rename(_sew_h2) TissueForge::models::vertex::Surface::sew(const std::vector<SurfaceHandle>&, const FloatP_t&);
 
 ///////////////////
 // SurfaceHandle //
@@ -92,6 +92,7 @@ vertex_solver_MeshObj_prep_py(TissueForge::models::vertex::Surface)
 %rename(_operator_vertices) TissueForge::models::vertex::SurfaceType::operator() (const std::vector<VertexHandle>&);
 %rename(_operator_positions) TissueForge::models::vertex::SurfaceType::operator() (const std::vector<FVector3>&);
 %rename(_operator_iofacedata) TissueForge::models::vertex::SurfaceType::operator() (TissueForge::io::ThreeDFFaceData*);
+%rename(_operator_iofacevectordata) TissueForge::models::vertex::SurfaceType::operator() (const std::vector<TissueForge::io::ThreeDFFaceData*>&, const bool&);
 %rename(_n_polygon) TissueForge::models::vertex::SurfaceType::nPolygon;
 %rename(_replace) TissueForge::models::vertex::SurfaceType::replace;
 
@@ -435,7 +436,7 @@ vertex_solver_MeshObjType_extend_py(TissueForge::models::vertex::SurfaceType)
             """flat surface constraints bound to the type"""
             return _vertex_solver_MeshObjActor_getFlatSurfaceConstraint(self)
 
-        def __call__(self, vertices=None, positions=None, face_data=None):
+        def __call__(self, vertices=None, positions=None, face_data=None, safe_face_data: bool = True):
             """
             Construct a surface of this type
 
@@ -453,7 +454,10 @@ vertex_solver_MeshObjType_extend_py(TissueForge::models::vertex::SurfaceType)
                         positions[i] = FVector3(*p)
                 result = self._operator_positions(positions)
             elif face_data is not None:
-                result = self._operator_iofacedata(face_data)
+                if isinstance(face_data, list) or isinstance(face_data, tuple):
+                    result = self._operator_iofacevectordata(face_data, safe_face_data)
+                else:
+                    result = self._operator_iofacedata(face_data)
 
             return result
 


### PR DESCRIPTION
* Adds parallel construction and destruction of all mesh objects
* Improves I/O throughput
* Parallelizes performance-critical mesh operations (e.g., sewing)
* Adds option to keep imported mesh topology

Thanks to @tc2fh for the tests and insights that motivated these improvements. 